### PR TITLE
feat:ヘッダーにログアウトボタンを追加

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server -b 0.0.0.0 -p 3000
-css: bin/rails tailwindcss:watchcss: bin/rails tailwindcss:watch
+css: bin/rails tailwindcss:watch

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
+    <%= render "shared/header" %>
     <!-- <main class="container mx-auto mt-28 px-5 flex"> -->
     <main>
       <%= yield %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,23 @@
+<%# ログイン後のヘッダー %>
+<header class="navbar bg-white border-b border-sage-100 fixed top-0 left-0 right-0 z-50">
+  <div class="navbar-start">
+    <%# link_to "Home", root_path, class: "btn btn-ghost normal-case text-xl" %>
+  </div>
+
+<div class="navbar-center">
+      <span class="font-title text-xl font-bold text-ink">Capture Your Day</span>
+</div>
+      <!-- navbar-end -->
+<div class="navbar-end">
+      <% if user_signed_in? %>
+        <%= link_to t('.logout'), destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "btn btn-primary btn-md hover:opacity-70" %>
+      <% else %>
+        <div class = "flex gap-4">
+        <%= link_to t('.register'), new_user_registration_path, class: "btn btn-primary btn-md hover:opacity-70" %>
+        <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md hover:opacity-70" %>
+        </div>      
+      <% end %>
+
+</div>
+
+</header>

--- a/compose.yml
+++ b/compose.yml
@@ -20,7 +20,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: bash -c "rm -f tmp/pids/server.pid && bin/rails server -b 0.0.0.0"
+    # command: bash -c "rm -f tmp/pids/server.pid && bin/rails server -b 0.0.0.0"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/dev"
     # 人が操作できる画面端末を用意する設定
     tty: true
     stdin_open: true

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,3 +13,9 @@ ja:
     registrations:
       new:
         title: 新規登録
+  shared:
+    header:
+      login: ログイン
+      logout: ログアウト
+      register: 新規登録
+


### PR DESCRIPTION

## 概要
ヘッダーにログアウトボタンを追加しました。
Deviseのログアウト機能をUIから利用できるようにしています。

## 変更内容

### ヘッダーの作成
- `app/views/shared/_header.html.erb` を新規作成
- DaisyUIの `navbar` コンポーネントを使用
- ログイン済み → ログアウトボタンを表示
- 未ログイン → ログイン・新規登録ボタンを表示

### レイアウトの修正
- `app/views/layouts/application.html.erb` にヘッダーのrenderを追加
- `user_signed_in?` でログイン状態を判定して出し分け

## 確認事項
- [x] ログアウトボタンが正常に動作する
- [x] 未ログイン時にログイン・新規登録ボタンが表示される
- [x] 認証画面ではヘッダーが非表示になっている


closed #18 