### PR TITLE
feat:model生成

### DIFF
--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,0 +1,9 @@
+class Journal < ApplicationRecord
+  belongs_to :user
+  has_many :mistakes, dependent: :destroy
+
+  validates :posted_date, presence: true
+  validates :body, presence: true
+
+  enum mood: { great: 0, good: 1, neutral: 2, bad: 3 }
+end

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -1,0 +1,6 @@
+class Mistake < ApplicationRecord
+  belongs_to :journal
+  belongs_to :user
+  validates :original_text, presence: true
+
+end

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -2,5 +2,4 @@ class Mistake < ApplicationRecord
   belongs_to :journal
   belongs_to :user
   validates :original_text, presence: true
-
 end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,0 +1,5 @@
+class NotificationSetting < ApplicationRecord
+  belongs_to :user
+  
+  enum scene_type: { light: 0, dark: 1 }
+end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,5 +1,5 @@
 class NotificationSetting < ApplicationRecord
   belongs_to :user
-  
+
   enum scene_type: { light: 0, dark: 1 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,10 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :journals, dependent: :destroy
+  has_many :mistakes, dependent: :destroy
+  has_one :notification_setting, dependent: :destroy
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 end

--- a/db/migrate/20260407081406_add_avatar_to_users.rb
+++ b/db/migrate/20260407081406_add_avatar_to_users.rb
@@ -1,0 +1,5 @@
+class AddAvatarToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :avatar, :string
+  end
+end

--- a/db/migrate/20260407090815_create_journals.rb
+++ b/db/migrate/20260407090815_create_journals.rb
@@ -1,0 +1,13 @@
+class CreateJournals < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journals do |t|
+      t.references :user, null: false, foreign_key: true
+      t.datetime :posted_date, null: false
+      t.integer :mood
+      t.string :title, null: true
+      t.text :body, null:false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260407090815_create_journals.rb
+++ b/db/migrate/20260407090815_create_journals.rb
@@ -5,7 +5,7 @@ class CreateJournals < ActiveRecord::Migration[7.2]
       t.datetime :posted_date, null: false
       t.integer :mood
       t.string :title, null: true
-      t.text :body, null:false
+      t.text :body, null: false
 
       t.timestamps
     end

--- a/db/migrate/20260407101344_create_mistakes.rb
+++ b/db/migrate/20260407101344_create_mistakes.rb
@@ -1,0 +1,13 @@
+class CreateMistakes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mistakes do |t|
+      t.references :journal, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :original_text, null: false
+      t.text :corrected_text
+      t.text :explanation
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260407111450_create_notification_settings.rb
+++ b/db/migrate/20260407111450_create_notification_settings.rb
@@ -1,0 +1,12 @@
+class CreateNotificationSettings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :notification_settings do |t|
+      t.references :user, null: false, foreign_key: true
+      t.boolean :reminder_enabled, default: false
+      t.time :notification_time
+      t.integer :scene_type, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,42 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_01_071700) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_07_111450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "journals", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "posted_date", null: false
+    t.integer "mood"
+    t.string "title"
+    t.text "body", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_journals_on_user_id"
+  end
+
+  create_table "mistakes", force: :cascade do |t|
+    t.bigint "journal_id", null: false
+    t.bigint "user_id", null: false
+    t.text "original_text", null: false
+    t.text "corrected_text"
+    t.text "explanation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journal_id"], name: "index_mistakes_on_journal_id"
+    t.index ["user_id"], name: "index_mistakes_on_user_id"
+  end
+
+  create_table "notification_settings", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.boolean "reminder_enabled", default: false
+    t.time "notification_time"
+    t.integer "scene_type", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_notification_settings_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -23,7 +56,13 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_01_071700) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "avatar"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "journals", "users"
+  add_foreign_key "mistakes", "journals"
+  add_foreign_key "mistakes", "users"
+  add_foreign_key "notification_settings", "users"
 end

--- a/test/fixtures/journals.yml
+++ b/test/fixtures/journals.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  posted_date: 2026-04-07 18:08:15
+  mood: 1
+  title: MyString
+  body: MyText
+
+two:
+  user: two
+  posted_date: 2026-04-07 18:08:15
+  mood: 1
+  title: MyString
+  body: MyText

--- a/test/fixtures/mistakes.yml
+++ b/test/fixtures/mistakes.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  journal: one
+  user: one
+  original_text: MyText
+  corrected_text: MyText
+  explanation: MyText
+
+two:
+  journal: two
+  user: two
+  original_text: MyText
+  corrected_text: MyText
+  explanation: MyText

--- a/test/fixtures/notification_settings.yml
+++ b/test/fixtures/notification_settings.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  reminder_enabled: false
+  notification_time: 2026-04-07 20:14:51
+  scene_type: 1
+
+two:
+  user: two
+  reminder_enabled: false
+  notification_time: 2026-04-07 20:14:51
+  scene_type: 1

--- a/test/models/journal_test.rb
+++ b/test/models/journal_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class JournalTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/mistake_test.rb
+++ b/test/models/mistake_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MistakeTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/notification_setting_test.rb
+++ b/test/models/notification_setting_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class NotificationSettingTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
モデルの生成・マイグレーションを行いました。

## タスク
モデル生成
- `app/models/journal.rb`
- `app/models/notification_setting.rb`
    scene_typeをenumで管理（light / dark）
- `app/models/mistake.rb`
- `app/models/user.rb`（Deviseで作成済み・avatarカラム追加）

closes #20 
closes #21 
closes #22 