### PR TITLE
ログイン画面の作成・新規登録画面でヘッダーの非表示

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 
 <!-- 新規会員登録画面 -->
-
+<% content_for :hide_header, true %>
 <%= render "devise/shared/auth_wrapper" do %>
 <h2 class="text-2xl font-bold mb-6 text-center"><%= sign_up_label = t('devise.registrations.new.sign_up') %> </h2>
 

--- a/app/views/devise/shared/_auth_wrapper.html.erb
+++ b/app/views/devise/shared/_auth_wrapper.html.erb
@@ -1,4 +1,4 @@
-<% content_for :hide_header, true %>
+<%# content_for :hide_header, true %>
 <% content_for :hide_footer, true %>
 
     <%# ── ロゴ ── %>
@@ -7,12 +7,16 @@
       <p class="text-sm text-ink-muted mt-1"> subtitle </p>
     </div> -->
 
-<div class="min-h-screen bg-sage-50 flex flex-col items-center justify-center px-4 py-12">
+<div class="min-h-screen bg-sage-50 flex flex-col items-center justify-center px-4 pb-12 pt-24">
   <div class="w-full max-w-lg">
     <%# ── ロゴ ── %>
     <div class="text-center mb-8">
-      <h1 class="text-2xl font-bold text-ink tracking-widest font-title">Capture Your Day</h1>
-      <p class="text-sm text-ink-muted mt-1"> subtitle </p>
+      <h1 class="font-title text-4xl font-bold text-ink">Capture Your Day</h1>
+      <!-- <h1 class="text-4xl  text-ink font-english">Capture Your Day</h1> -->
+      <!-- <h1 class="font-cormorant text-4xl font-bold text-ink">Capture Your Day</h1> -->
+
+      
+      <p class="text-md text-ink-muted mt-4"> Write your day. Keep your growth. </p>
     </div>
     <div class="bg-white border border-sage-100 rounded-3xl p-10 shadow-sm">
     <!-- <div class="bg-washi rounded-3xl border border-washi-border shadow-md p-8"> -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
-    <%= render "shared/header" %>
+    <%= render "shared/header" unless content_for?(:hide_header) %>
     <!-- <main class="container mx-auto mt-28 px-5 flex"> -->
     <main>
       <%= yield %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,13 @@
 <%# ログイン後のヘッダー %>
 <header class="navbar bg-white border-b border-sage-100 fixed top-0 left-0 right-0 z-50">
   <div class="navbar-start">
+    <span class="font-title text-2xl font-bold text-ink">Capture Your Day</span>
     <%# link_to "Home", root_path, class: "btn btn-ghost normal-case text-xl" %>
   </div>
 
-<div class="navbar-center">
-      <span class="font-title text-xl font-bold text-ink">Capture Your Day</span>
+<div class="navbar-center">    
+      <!-- <span class="font-english text-xl text-ink">Capture Your Day</span> -->
+      <!--<h1 class="font-cormorant text-2xl font-bold text-ink">Capture Your Day</h1> -->
 </div>
       <!-- navbar-end -->
 <div class="navbar-end">
@@ -13,11 +15,15 @@
         <%= link_to t('.logout'), destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "btn btn-primary btn-md hover:opacity-70" %>
       <% else %>
         <div class = "flex gap-4">
-        <%= link_to t('.register'), new_user_registration_path, class: "btn btn-primary btn-md hover:opacity-70" %>
-        <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md hover:opacity-70" %>
-        </div>      
+        <%= link_to t('.register'), new_user_registration_path, class: "btn btn-primary btn-md px-6 text-sm  sm:text-base min-h-11 h-11 hover:opacity-70" %>
+      
+        <% if current_page?(new_user_session_path) %>
+          <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md px-6 text-sm sm:text-base h-11 min-h-11 opacity-60 pointer-events-none" %>
+        <% else %>
+          <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md px-6 text-sm sm:text-base h-11 min-h-11 hover:opacity-70" %>
+        <% end %>
       <% end %>
-
+        </div>    
 </div>
 
 </header>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -12,7 +12,10 @@ module.exports = {
     extend: {
     fontFamily: {
       sans:  ['"Noto Sans JP"', 'sans-serif'],
-      title: ['"Libre Baskerville"', 'serif'],
+      // title2: ['"Libre Baskerville"', 'serif'],
+      title:  ['"Playfair Display"',   'serif'], //1
+      english: ['"DM Serif Display"', 'serif'], //2
+      cormorant: ['"Cormorant Garamond"', 'serif'], //3
     },
       colors: {
         sage: {

--- a/test/integration/registration_layout_test.rb
+++ b/test/integration/registration_layout_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class RegistrationLayoutTest < ActionDispatch::IntegrationTest
+  test "sign up page does not render the shared header" do
+    get new_user_registration_path
+
+    assert_response :success
+    assert_select "header.navbar", count: 0
+  end
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 概要
ログイン画面の作成・新規登録画面でヘッダーとフッターを非表示にした。

## 変更内容
- `application.html.erb` にヘッダーの表示条件を追加
- `sessions/new.html.erb`（ログイン）の作成
- `registrations/new.html.erb`（新規登録）に `content_for :hide_header` を追加

## 確認方法
- [x] ログイン画面の確認
- [x] 新規登録画面でヘッダーが非表示になっている
- [x] 新規登録画面以外のページでヘッダーが表示されている

## 関連Issue
closes #30 