### PR TITLE
フラッシュメッセージ設定（新規登録・ログイン・ログアウト時）

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,10 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :name ])
   end
+  # ログアウト後はログイン画面へ
+  def after_sign_out_path_for(_resource_or_scope)
+    new_user_session_path
+  end
   # protected
   #   # アカウント更新（編集）時に :username カラムを許可する場合
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:username])

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,7 +18,7 @@
     </div> -->    
 
     <%# ── バリデーションエラー ── %>
-    <% if resource.errors.any? %>
+    <!--<% if resource.errors.any? %>
       <div role="alert" class="alert alert-error mb-4">
         <p class="font-bold mb-1">入力内容を確認してください</p>
         <ul>
@@ -27,10 +27,14 @@
           <% end %>
         </ul>
       </div>
-    <% end %>
+    <% end %> -->
     
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>  
+  <% if resource.errors.any? %>
+  <div role="alert" class="alert alert-error mb-4">
   <%= render "devise/shared/error_messages", resource: resource %>
+  </div>
+  <% end %>
 
   <div class="mb-4">
     <p><%= f.label :name, class: "block text-sm font-medium text-ink-sub mb-1" %></p>

--- a/app/views/devise/shared/_auth_wrapper.html.erb
+++ b/app/views/devise/shared/_auth_wrapper.html.erb
@@ -7,7 +7,7 @@
       <p class="text-sm text-ink-muted mt-1"> subtitle </p>
     </div> -->
 
-<div class="min-h-screen bg-sage-50 flex flex-col items-center justify-center px-4 pb-12 pt-24">
+<div class="min-h-screen bg-sage-50 flex flex-col items-center justify-center px-4 pb-12 pt-4">
   <div class="w-full max-w-lg">
     <%# ── ロゴ ── %>
     <div class="text-center mb-8">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <!-- <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Noto+Sans+JP:wght@400;500&display=swap" rel="stylesheet"> -->
 
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=DM+Serif+Display:ital@0;1&family=Playfair+Display:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/maanifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
@@ -25,10 +25,13 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
   </head>
 
-  <body class="flex flex-col min-h-screen">
+  <body class="flex flex-col min-h-screen bg-sage-50">
     <%= render "shared/header" unless content_for?(:hide_header) %>
     <!-- <main class="container mx-auto mt-28 px-5 flex"> -->
-    <main>
+    <!-- フラッシュメッセージ -->
+
+    <main class="pt-20 ">
+      <%= render "shared/flash_message" %>
       <%= yield %>
     </main>
      <%# render "shared/footer" %>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,17 @@
+<%# flash の種類ごとに DaisyUI の alert クラスを切り替える %>
+<% flash.each do |type, message| %>
+  <% next if message.blank? %>
+
+  <% alert_class = case type.to_sym
+    when :notice then "alert alert-success"
+    when :alert  then "alert alert-error"
+    else              "alert alert-info"
+    end
+  %>
+
+  <div class="mx-auto w-full max-w-3xl px-4">
+    <div role="alert" class="<%= alert_class %> shadow-sm">
+      <span><%= message %></span>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -125,7 +125,7 @@ ja:
 
 
     sessions:
-      already_signed_out: 既にログアウト済みです。
+      already_signed_out: ログアウト済みです。
       new:
         sign_in: ログイン
       signed_in: ログインしました。

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,6 +13,7 @@ ja:
     registrations:
       new:
         title: 新規登録
+    sessions:
   shared:
     header:
       login: ログイン

--- a/test/integration/registration_layout_test.rb
+++ b/test/integration/registration_layout_test.rb
@@ -1,10 +1,57 @@
 require "test_helper"
 
 class RegistrationLayoutTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
   test "sign up page does not render the shared header" do
     get new_user_registration_path
 
     assert_response :success
     assert_select "header.navbar", count: 0
+  end
+
+  test "sign up shows a flash message after success" do
+    assert_difference("User.count", 1) do
+      post user_registration_path, params: {
+        user: {
+          name: "flash user",
+          email: "flash_signup@example.com",
+          password: "password",
+          password_confirmation: "password"
+        }
+      }
+    end
+
+    follow_redirect!
+
+    assert_response :success
+    assert_select "[role=alert]", text: /アカウント登録が完了しました。/
+  end
+
+  test "sign in shows a flash message after success" do
+    post user_session_path, params: {
+      user: {
+        email: users(:one).email,
+        password: "password"
+      }
+    }
+
+    follow_redirect!
+
+    assert_response :success
+    assert_select "[role=alert]", text: /ログインしました。/
+  end
+
+  test "sign out shows a flash message after success" do
+    sign_in users(:one)
+
+    delete destroy_user_session_path
+
+    assert_redirected_to new_user_session_path
+
+    follow_redirect!
+
+    assert_response :success
+    assert_select "[role=alert]", text: /ログアウトしました。/
   end
 end


### PR DESCRIPTION
## 概要
新規登録・ログイン・ログアウト時のフラッシュメッセージの設定

## 変更内容
### 新規作成
- `app/views/shared/_flash_message.html.erb`

### 修正
- `app/views/layouts/application.html.erb`
  - ヘッダーに隠れない位置に表示されるよう調整
  
- `app/controllers/application_controller.rb`
  - `after_sign_out_path_for` を追加
  - ログアウト後の遷移先を `new_user_session_path` に変更
  - `authenticate_user!` によるフラッシュ上書き問題を解消
  
- `config/locales/devise.ja.yml`
  - 登録完了・ログイン・ログアウト時の文言を少し修正

## 確認方法
- [x] 新規登録後に「アカウント登録が完了しました」が表示される
- [x] ログイン後に「ログインしました」が表示される
- [x] ログアウト後に「ログアウトしました」が表示される
- [x] バリデーションエラーが赤い枠で箇条書き表示される
- [x] フラッシュがヘッダーに隠れない

## 関連Issue
closes #34 