### PR TITLE
fix: assets precompile時にResend設定で落ちる問題を修正

### DIFF
--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -2,8 +2,6 @@ require "resend"
 
 resend_api_key = ENV["RESEND_API_KEY"]
 
-if resend_api_key.present?
-  Resend.api_key = resend_api_key
-elsif Rails.env.production?
-  raise KeyError, "key not found: \"RESEND_API_KEY\""
+if ENV["RESEND_API_KEY"].present?
+  Resend.api_key = ENV["RESEND_API_KEY"]
 end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 概要
本番環境で assets:precompile 実行時に exit code: 1 エラーが発生したため修正しました。

## 原因
`RESEND_API_KEY` 未設定時に initializer がエラーとなっていました。

## 対応内容
- initializer の条件分岐を修正
- build 環境でも precompile 可能に変更
