### PR TITLE
feat:404/500エラーページを日本語対応

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,11 @@ class ApplicationController < ActionController::Base
   # Devise のデフォルトで用意されているカラム（email, password など）以外に、独自のカラム（例：username）を追加したい場合に必要になる設定
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  # 500エラー確認用（終わったら削除！）
+  # skip_before_action :authenticate_user!, only: [:test500]
+  # def test500
+  #   raise "テスト用500エラー"
+  # end
 
   protected
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,8 +11,8 @@
     <%= link_to "ホーム", root_path, class: "btn btn-ghost normal-case text-lg" %>
     <%= link_to "今日の日記", "#", class: "btn btn-ghost normal-case text-lg" %>
     <%= link_to "ジャーナル一覧", "#", class: "btn btn-ghost normal-case text-lg" %>
-    <%= link_to "学び", "#", class: "btn btn-ghost normal-case text-lg" %>
     <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-lg" %>
+    <%= link_to "学び", "#", class: "btn btn-ghost normal-case text-lg" %>
     <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-lg" %>
   </span>
   <% else %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports.
+  # Show full error reports.　エラーチェックのため一時的にfalseにする
   config.consider_all_requests_local = true
 
   # Enable server timing.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@ Rails.application.routes.draw do
   resources :mistakes, only: [ :index, :show, :new, :create, :destroy ]
   resource :user, only: [ :show, :edit, :update, :destroy ]
 
+  # テスト用ルーティング　あとで削除する
+  # get '/test500', to: 'application#test500'
+
   # ヘルスチェック
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
+  <title>ページが見つかりません (404)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -26,13 +26,15 @@
     border-top: #B00100 solid 4px;
     border-top-left-radius: 9px;
     border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
     background-color: white;
-    padding: 7px 12% 0;
+    padding: 16px 12% 24px;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
+    font-size: 1.4rem;
     color: #730E15;
     line-height: 1.5em;
   }
@@ -51,6 +53,18 @@
     color: #666;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
+
+  /* ホームに戻るリンク */
+  .rails-default-error-page a {
+    display: inline-block;
+    margin-top: 16px;
+    padding: 8px 20px;
+    background-color: #730E15;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.9rem;
+  }
   </style>
 </head>
 
@@ -58,10 +72,15 @@
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <div>
-      <h1>The page you were looking for doesn't exist.</h1>
-      <p>You may have mistyped the address or the page may have moved.</p>
+      <h1>404 File Not Found</h1>
+      <h2>ページが見つかりませんでした。</h2>
+      <p>アクセスしようとしたページは、
+      <br> 移動あるいは削除された可能性があります。</br> </p>
+      <a href="/">ホーム画面に戻る</a>
     </div>
-    <p>If you are the application owner check the logs for more information.</p>
   </div>
+    <!-- </div>
+    <p><a href="/">ホーム画面に戻る</a></p>
+  </div> -->
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -27,13 +27,15 @@
     border-top: #B00100 solid 4px;
     border-top-left-radius: 9px;
     border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
     background-color: white;
-    padding: 7px 12% 0;
+    padding: 7px 12% 24px;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
 
   .rails-default-error-page h1 {
-    font-size: 100%;
+    font-size: 1.4rem;
     color: #730E15;
     line-height: 1.5em;
   }
@@ -52,6 +54,19 @@
     color: #666;
     box-shadow: 0 3px 8px rgba(50, 50, 50, 0.17);
   }
+
+    /* ホームに戻るリンク */
+  .rails-default-error-page a {
+    display: inline-block;
+    margin-top: 16px;
+    padding: 8px 20px;
+    background-color: #730E15;
+    color: white;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.9rem;
+  }
+  
   </style>
 </head>
 
@@ -60,15 +75,16 @@
   <div class="dialog">
     <div>
       <h1>サーバーエラーが発生しました</h1>
-    </div>
-    <p>I 申し訳ありません。しばらく時間をおいてから<br>
-        再度アクセスしてください。
+    
+    <p>申し訳ありません。<br>
+        しばらく時間をおいてから、再度アクセスしてください。
     </p>
-    <a href="/"
+    <!--<a href="/"
         class="inline-block px-6 py-3 rounded-full text-white font-medium text-sm"
-        style="background-color: #d97706;">
-        ホームへ戻る
+        style="background-color: #d97706;"> -->
+        <a href="/">ホームへ戻る</a>
     </a>
+    </div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 概要
デフォルトのエラーページ（404・500）を日本語対応にしました。

## 変更内容
- `public/404.html` を日本語表記に変更
- `public/500.html` を日本語表記に変更
- 「ホーム画面に戻る」リンクを追加

## 関連Issue
closes #39 