### PR TITLE
feat:ジャーナリング一覧画面作成

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -1,7 +1,8 @@
 class JournalsController < ApplicationController
   before_action :authenticate_user!
   def index
-    @journals =current_user.journals.order(created_at: :desc).limit(3)
+    @journals =current_user.journals.order(created_at: :desc)
+    # @journals =current_user.journals.order(created_at: :desc).limit(3)
   end
 
   def show

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,18 +1,24 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div>
-  <h1 class="font-bold text-4xl">Journals#index</h1>
-  <p>Find me in app/views/journals/index.html.erb</p>
 
-    <div class="actions">
-  <%= link_to "Write today's journal", new_journal_path(posted_date:Date.current), class:"btn btn-primary" %>
-  </div>
-  <div class="container" >
-   <h1 class="font-title font-bold"> My Journal </h1>
+<div class="max-w-3xl mx-auto">
+  <h1 class="font-bold font-title text-3xl text-center font-cream-500 mt-4 mb-5">
+  My Journal
+  </h1>
 
-   <h2 class="font-size font-bold">Recent Journals</h2>
+    <!-- <div class="actions mb-4">
+  <%= link_to "日記を書く", new_journal_path(posted_date:Date.current), class:"btn btn-primary" %>
+  </div> -->
+
    <% @journals.each do |journal| %>
-    <p>
-    <strong><%= journal.posted_date %></strong>
+    <%#　1件ずつ枠で囲む  %>
+    <div class="border border-cream-300 bg-white rounded-lg px-3 py-2 mb-4">
+    <p class="font-bold text-cream-500 mb-3">
+    <%= link_to journal.posted_date.strftime("%Y/%m/%d"), journal_path(journal) %>
+      <p class="mb-3 line-clamp-2">
+        <%= journal.body %>
+      </p>
     </p>
+    </div>
   <% end %>
+
 </div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -9,16 +9,18 @@
   <%= link_to "日記を書く", new_journal_path(posted_date:Date.current), class:"btn btn-primary" %>
   </div> -->
 
-   <% @journals.each do |journal| %>
-    <%#　1件ずつ枠で囲む  %>
-    <div class="border border-cream-300 bg-white rounded-lg px-3 py-2 mb-4">
-    <p class="font-bold text-cream-500 mb-3">
-    <%= link_to journal.posted_date.strftime("%Y/%m/%d"), journal_path(journal) %>
-      <p class="mb-3 line-clamp-2">
-        <%= journal.body %>
+    <%# 日記一覧をループ %>
+    <% @journals.each do |journal| %>
+      <%#　1件ずつ枠で囲む  %>
+      <%= link_to journal_path(journal), class:"block border border-cream-300 bg-white rounded-lg px-3 py-2 mb-4" do %>
+      
+      <p class="font-bold text-cream-500 mb-3">
+      <%= journal.posted_date.strftime("%Y/%m/%d") %>
       </p>
-    </p>
-    </div>
-  <% end %>
-
+      
+      <p class="mb-3 line-clamp-2">
+          <%= journal.body %>
+      </p>
+      <% end %>
+    <% end %>
 </div>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,5 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="max-w-2xl mx-auto px-4 py-6">
-  <h1 class="font-sans font-bold text-4xl mb-5 text-center"><%= t('.title') %></h1>
-    <%= render 'form', journal:@journal %>
-</div>
+<main class="flex-grow pt-10 px-10"> 
+  <div class="max-w-2xl mx-auto px-4 py-6">
+    <h1 class="font-sans font-bold text-4xl mb-5 text-center"><%= t('.title') %></h1>
+      <%= render 'form', journal:@journal %>
+  </div>
+</main>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,8 +10,8 @@
   <% if user_signed_in? %>
   <span>
     <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "今日の日記", "#", class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "ジャーナル一覧", "#", class: "btn btn-ghost normal-case text-md" %>
+    <%= link_to "今日の日記", new_journal_path, class: "btn btn-ghost normal-case text-md" %>
+    <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "学び", "#", class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md" %>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 概要
`journals/index.html.erb` のジャーナリング一覧画面を実装しました。

## 変更内容
- ジャーナリング一覧の表示を実装
- 日付ごとにカード形式で区切りを表示
- 本文は2行でクリップ（`line-clamp-2`）

## 関連Issue
closes #43 