### PR TITLE
fix:ジャーナル詳細画面の改善

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <main class="flex-grow pt-10 px-10">
-  <div class="max-w-3xl mx-auto">
+  <div class="max-w-3xl mx-auto md:px-0">
   <h1 class="font-title font-bold text-4xl mb-5">
     <%= current_user.name %>'s Journal
   </h1>

--- a/app/views/journals/_form.html.erb
+++ b/app/views/journals/_form.html.erb
@@ -32,7 +32,8 @@
   </div> -->
   <div class="mb-3">
     <%= f.label :body, class:"label label-text text-base font-medium" %>
-    <%= f.text_area :body, class: "textarea textarea-bordered w-full text-base", rows: "10", placeholder:"今日の出来事や気持ちを、英語または日本語で書いてみましょう" %>
+    <%= f.text_area :body, class: "textarea textarea-bordered w-full text-base", rows: "10", 
+        placeholder:"今日、心が動いたことは？\n今日の出来事や気持ちを、英語または日本語で書いてみましょう" %>
   </div>
 
   <div class="mb-4">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 
-<div class="max-w-3xl mx-auto px-4 md:px-0">
+<div class="max-w-3xl mx-auto md:px-0">
   <h1 class="font-bold font-title text-3xl text-center font-cream-500 mt-7 mb-5">
   My Journal
   </h1>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <main class="flex-grow px-10"> 
-  <div class="max-w-2xl mx-auto px-4 py-6">
+  <div class="max-w-2xl mx-auto md:px-0">
     <h1 class="font-sans font-bold text-3xl mb-5 text-center"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -1,10 +1,10 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <main class="flex-grow px-10">
 
-<div class="max-w-2xl mx-auto px-4 py-6">
+<div class="max-w-3xl mx-auto md:px-0">
   
   <%# ページタイトル %>
-  <h1 class="font-sans font-bold text-4xl text-center mb-5">
+  <h1 class="font-sans font-bold text-4xl text-center py-5">
     <%= t('.title') %>
   </h1>
 
@@ -12,7 +12,7 @@
   <div class="card bg-forest-100 mb-4">
     <div class="card-body">
       <h2 class="card-title">元の文章</h2>
-      <div class="border border-gray-300 bg-white rounded-2xl p-3">
+      <div class="border border-gray-300 bg-white rounded-2xl p-5">
         <%= @overall&.original_text %>
       </div>
     </div>
@@ -23,7 +23,7 @@
   <div class="card bg-forest-100 mb-4">
     <div class="card-body">
       <h2 class="card-title">添削後の文章</h2>
-      <div class="border border-gray-300 bg-white rounded-2xl p-3">
+      <div class="border border-gray-300 bg-white rounded-2xl p-5">
         <%= @overall&.corrected_text %>
       </div>
     </div>
@@ -35,8 +35,8 @@
       <div class="card-body">
         <h2 class="card-title mb-3">今回の学び（<%= @mistakes.size %>件）</h2>
 
-        <% @mistakes.each do |mistake| %>
-          <div class="border border-gray-300 bg-white rounded-2xl p-3 mb-3">
+        <div class="border border-gray-300 bg-white rounded-2xl p-5 mb-4">
+        <!--<% @mistakes.each do |mistake| %>
 
             <%# 間違いの種類バッジ %>
             <span class="badge badge-outline badge-sm mb-2">
@@ -46,16 +46,27 @@
             <%# 元の表現 → 修正後 %>
             <p>
               <span class="line-through text-error"><%= mistake.original_text %></span>
-              →
-              <span class="font-bold text-success"><%= mistake.corrected_text %></span>
             </p>
+              <p>→
+              <span class="font-bold text-success"><%= mistake.corrected_text %></span>
+              </p>
 
             <%# 日本語説明 %>
             <p class="text-sm mt-1"><%= mistake.explanation %></p>
-
-          </div>
-        <% end %>
-
+        <% end %> -->
+          <ol class="list-decimal list-inside">
+          <% @mistakes.each do |mistake| %>
+          <li>
+          <div class="mb-4">
+          <p class="font-semibold">### <%= mistake.mistake_type %></p>
+          <p class="text-base">  【元の文章】: <%= mistake.original_text %></p>
+          <p class="text-base">  【添削後】: <%= mistake.corrected_text %></p>
+          <p class="text-sm text-gray-600">  ポイント: <%= mistake.explanation %></p>
+        </div>
+          </li>
+         <% end %>
+         </ol>
+         </div>
       </div>
     </div>
   <% else %>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 概要
ジャーナル詳細画面（journals#show）のUIを修正

## 変更内容
 ### UI関連

  - ジャーナル詳細画面（journals#show）のレイアウトを調整
  - 元の文章、添削後の文章、今回の学びの表示バランスを調整
  - 今回の学びを一覧形式で見やすく表示できるよう調整
  - フォームの見た目を一部調整
      本文入力欄の文字サイズと placeholder を調整

## 確認方法
 - ジャーナル詳細画面で元の文章、添削後の文章、今回の学びが正しく表示されること
  - ホーム画面、一覧画面、詳細画面の横幅や表示バランスに大きな崩れがないこと

## 関連Issue
closes #53 