### PR TITLE
ジャーナリング詳細画面・今回の学び修正

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -1,4 +1,5 @@
 class JournalsController < ApplicationController
+  helper MistakesHelper
   before_action :authenticate_user!
   def index
     @journals =current_user.journals.order(created_at: :desc)

--- a/app/helpers/mistakes_helper.rb
+++ b/app/helpers/mistakes_helper.rb
@@ -1,2 +1,13 @@
 module MistakesHelper
+  def mistake_type_label(mistake_type)
+    case mistake_type.to_s
+    when "grammar" then "grammar(文法)"
+    when "spelling" then "spelling(スペル)"
+    when "word_choice" then "word choice(単語選択)"
+    when "expression" then "expression(表現)"
+    when "translation" then "translation(翻訳)"
+    when "overall" then "overall(全体)"
+    else mistake_type
+    end
+  end
 end

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <main class="flex-grow px-10"> 
-  <div class="max-w-2xl mx-auto md:px-0">
+  <div class="max-w-3xl mx-auto md:px-0">
     <h1 class="font-sans font-bold text-3xl mb-5 text-center"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -56,12 +56,14 @@
         <% end %> -->
           <ol class="list-decimal list-inside">
           <% @mistakes.each do |mistake| %>
-          <li>
+          
           <div class="mb-4">
-          <p class="font-semibold">### <%= mistake.mistake_type %></p>
-          <p class="text-base">  【元の文章】: <%= mistake.original_text %></p>
-          <p class="text-base">  【添削後】: <%= mistake.corrected_text %></p>
-          <p class="text-sm text-gray-600">  ポイント: <%= mistake.explanation %></p>
+          <li>
+          <span class="font-semibold">
+          <%= mistake_type_label(mistake.mistake_type) %></span>
+          <p class="text-base font-normal">  【元の文章】: <%= mistake.original_text %></p>
+          <p class="text-base font-normal">  【添削後】: <%= mistake.corrected_text %></p>
+          <p class="text-sm text-gray-600 font-normal">  ポイント: <%= mistake.explanation %></p>
         </div>
           </li>
          <% end %>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 概要
  ジャーナル詳細画面の表示と余白を調整

## 変更内容
- app/views/journals/show.html.erb
  ジャーナル詳細画面の「今回の学び」表示を以下の文言で表示するようにした。
・grammar(文法)
・spelling(スペル)
・word choice(単語選択)
・expression(表現)
・translation(翻訳)
・overall(全体)

## 関連Issue
closes #105 