### PR TITLE
学びページ用にjournal_correctionsを作成

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -1,0 +1,11 @@
+class JournalCorrectionsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @journal_corrections = current_user.journal_corrections.includes(:journal, :mistakes).order(created_at: :desc)
+  end
+
+  def show
+    @journal_correction = current_user.journal_corrections.includes(:mistakes, :journal).find(params[:id])
+  end
+end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -2,15 +2,17 @@ class JournalsController < ApplicationController
   helper MistakesHelper
   before_action :authenticate_user!
   def index
-    @journals =current_user.journals.order(created_at: :desc)
-    # @journals = current_user.journals.includes(:mistakes).order(created_at: :desc)
+    # @journals =current_user.journals.order(created_at: :desc)
+    @journals =current_user.journals.includes(:journal_correction).order(created_at: :desc)
   end
 
   def show
     @journal = current_user.journals.find(params[:id])
-    @overall = @journal.mistakes.find_by(mistake_type: "overall")
-    @mistake = @journal.mistakes.first
-    @mistakes = @journal.mistakes.where.not(mistake_type: "overall")
+    # @overall = @journal.mistakes.find_by(mistake_type: "overall")
+    # @mistake = @journal.mistakes.first
+    # @mistakes = @journal.mistakes.where.not(mistake_type: "overall")
+    @journal_correction = @journal.journal_correction
+    @mistakes = @journal_correction&.mistakes || []
   end
 
   def new
@@ -36,11 +38,13 @@ class JournalsController < ApplicationController
 
     prompt = <<~PROMPT
     You are a bilingual Japanese-English writing coach and a native speaker of American English.
-
     The user may write in Japanese or English.
 
     Your job is to REWRITE the user's message into natural, emotionally authentic American English without changing the original meaning.
 
+    ====================
+    REWRITE RULES
+    ====================
     Important:
     - Do NOT translate literally.
     - Do NOT preserve awkward wording.
@@ -52,6 +56,7 @@ class JournalsController < ApplicationController
     - Understand Japanese nuance deeply before rewriting into natural American English.
     - Preserve the original meaning, emotional nuance, and timeline.
     - If the text is in Japanese, follow the flow of the original Japanese writing and rewrite the intended meaning into natural American English.
+
     #{' '}
     Tone:
     polite:
@@ -69,7 +74,6 @@ class JournalsController < ApplicationController
     Like a real native American writing privately.
     Default natural tone.
 
-
     casual:
     Warm, relaxed, conversational natural American English.
     More spontaneous and emotionally close.
@@ -77,27 +81,78 @@ class JournalsController < ApplicationController
     Simple wording should not oversimplify meaning.
     More immediate and human.
 
-
     Current tone: #{tone}
+    ====================
+    CORRECTION RULES
+    ====================
+    - Return all important corrections found in the text.
+    - Do not skip clear mistakes.
 
-    Correction Rules:
-    - Return ALL corrections without any limit on the number.
-    - Include EVERY grammar, spelling, word_choice, expression, and translation issue found.
-    - Do NOT summarize or skip any issues, even if the text is long.
-    - Do NOT stop at 3, 5, or any fixed number. Return every single issue.
-    - For each issue, classify it using exactly one of these mistake_type values:
-        "grammar"     : 文法の誤り
-        "spelling"    : スペルの誤り
-        "word_choice" : 単語選択の誤り
-        "expression"  : 不自然な言い回し
-        "translation" : 日本語から英語への翻訳ポイント
-    - Explain each issue briefly in Japanese.
-    - Avoid overexplaining grammar.
+    For each issue, use one mistake_type only:
+    grammar
+    spelling
+    word_choice
+    expression
+    translation
 
+    For every note, return:
+    - original_text
+    - corrected_text
+    - mistake_type
+    - explanation (Japanese)
+
+    GRAMMAR EXPLANATIONS:
+    - Be practical and beginner-friendly.
+    - Explain what was wrong in THIS sentence.
+    - Show how to write it correctly next time.
+    - Prefer reusable patterns over abstract grammar labels.
+    - Explanations must help the learner write the sentence correctly next time.
+
+    Examples:
+    go to + place
+    want to + verb
+    a + singular noun
+    yesterday + past tense
+    He/She/It + verb-s
+
+    Good example:
+    「前置詞：『部屋へ行く』は go to + place を使います。」
+    「時制：yesterday があるので過去形 went を使います。」
+
+    OTHER TYPES:
+    - Keep explanations short and clear.
+    - Focus on what sounds natural and how to improve.
+
+    - Use this format:
+    「ルール名：今回なぜ直すのか。どう考えればよいか。」
+      Example: 「時制の誤り：yesterday があるので、現在形ではなく過去形 went を使います。」
+      Example: 「主語と動詞の不一致：主語が三人称単数のときは動詞に -s が必要です。」
+    - For other mistake types, explain briefly in Japanese.
+    - Avoid overexplaining non-grammar issues.
+
+    ====================
+    ENGLISH FEEDBACK
+    ====================
+    Based only on THIS text, return:
+
+    - strengths (what user does well)
+    - mistake_patterns (repeated tendencies)
+    - advice (one short tip)
+
+    Be honest, helpful, supportive.
+
+    ====================
+    INPUT
+    ====================
       Input text:
       "#{body}"
 
-      Return Only this JSON format:
+    ====================
+    OUTPUT JSON ONLY
+    ====================
+      Do not omit any keys.
+      Return Only this JSON format
+      Use exactly this structure:
       {
         "rewritten_text": "添削後の英文をここに",
         "notes":[
@@ -107,11 +162,78 @@ class JournalsController < ApplicationController
             "mistake_type": "grammar or spelling or word_choice or expression or translation",
             "explanation": "日本語で簡潔な説明"
           }
-        ]
+        ],
+      "english_feedback": {
+        "strengths": [
+        "point": "英語表現上のよかった点",
+        "evidence": "元の文または修正文の具体例",
+        "why_it_works": "なぜよいのかを日本語で1文"
+        ],
+        "mistake_patterns": [
+          "point": "この文で見られた英語の傾向や弱点を分かりやすく。",
+          "evidence": "元の文の具体例",
+          "explanation": "このミスがなぜ起きているか、どう直すべきかを日本語で1〜2文。前置詞であればどうすべきか、時制ならどうすべきかなど具体的に"
+        ],
+        "advice": {
+          "point": "この文から言える短い改善アドバイス",
+          "evidence": "どのミスを根拠にしているか"
+        }
+       }
       }
 
-      If the input is Japanese, return translation notes explaining key phrasing choices.
-      key translation choices (e.g. why a particular word or phrase was chosen).
+      ====================
+      ENGLISH FEEDBACK
+      ====================
+      Analyze the user's ENGLISH usage only.
+      Do NOT comment on emotions, story content, personality, or life situation.
+      Focus only on English writing.
+      Focus only on:
+      - grammar tendencies
+      - common mistake patterns
+      - vocabulary usage
+      - sentence structure
+      - naturalness of English
+      - If the original input is primarily Japanese, return "strengths": [].
+
+      Return:
+      - strengths = what the user does well in English
+      - mistake_patterns = repeated English mistakes or weak areas
+      - advice = one short practical study tip in Japanese based only on the mistakes in this text
+      - If there is not enough evidence, return an empty array.
+      - Do not make the feedback overly short.
+      - Each explanation should be concrete and specific to this text.
+      - Strengths must describe specific English skills shown in THIS text.
+      - Avoid generic comments.
+
+
+      Examples of good strengths:
+      - 状況説明の語順が自然です
+      - 会話で使える自然な表現を選べています
+      - 文の流れが自然です
+
+      Examples of good mistake_patterns:
+      - 前置詞が抜けやすいです
+      - 時制が混ざりやすいです
+      - 冠詞 a / the を忘れやすいです
+      - 日本語直訳の語順になりやすいです
+
+      Bad examples:
+      - 気持ちがよく伝わります
+      - 内容が具体的です
+      - 感情表現が豊かです
+      - 出来事をよく振り返れています
+      - 感情を英語で表現できています
+      - 文の流れが自然です
+
+      Examples of advice:
+      - 移動を表す go は go to + 場所 を意識すると自然になります。
+
+      Do NOT analyze personality or emotional content.
+      Use only this text as evidence.
+
+      If the input contains Japanese text, classify all rewriting choices as "translation" type.
+      For each translation note, explain in Japanese why the specific English word or phrase was chosen to express the original Japanese nuance.
+      english_feedback must be based only on THIS text.Be practical, modest, and helpful.
       If there are no notes, return "notes": []
       PROMPT
 
@@ -125,13 +247,15 @@ class JournalsController < ApplicationController
           messages: [ { role: "user", content: prompt } ],
           response_format: { type: "json_object" },
 
-          temperature: 0.7
+          temperature: 1.0
         }
       )
 
       # 5 AIからのJSON応答をパースする
       raw_response = response.dig("choices", 0, "message", "content")
       result = JSON.parse(raw_response)
+      Rails.logger.debug "=== result: #{result.inspect}"
+      Rails.logger.debug "=== english_feedback: #{result['english_feedback'].inspect}"
 
       # 6 DBに保存する
       # @journal = current_user.journals.build(
@@ -140,24 +264,52 @@ class JournalsController < ApplicationController
 
       if @journal.save
 
-        # 7. 添削後の全文と各指摘をmistakesに保存する
-        @journal.mistakes.create!(
+        # 7.添削後の全文をjournal_correctionsに保存する
+        # mistakesにデータを保存する
+        correction = @journal.create_journal_correction!(
           user_id: current_user.id,
           original_text: body,
-          corrected_text: result["rewritten_text"],
-          mistake_type: :overall
-          )
+          rewritten_text: result["rewritten_text"],
+          strengths: result.dig("english_feedback", "strengths"),
+          mistake_patterns: result.dig("english_feedback", "mistake_patterns"),
+          advice: result.dig("english_feedback", "advice", "point")
+        )
 
-          # 8 個別の指摘をmistakesに1件ずつ保存する
-          (result["notes"] || []).each do |note|
-            @journal.mistakes.create!(
-              user_id: current_user.id,
-              original_text: note["original_text"],
-              corrected_text: note["corrected_text"],
-              mistake_type: note["mistake_type"],
-              explanation: note["explanation"]
+        (result["notes"] || []).each do |note|
+          correction.mistakes.create!(
+            journal: @journal,
+            user: current_user,
+            original_text: note["original_text"],
+            corrected_text: note["corrected_text"],
+            mistake_type: note["mistake_type"],
+            explanation: note["explanation"]
           )
         end
+
+        # 7. 添削後の全文と各指摘をmistakesに保存する
+        # @journal.mistakes.create!(
+        #   user_id: current_user.id,
+        #   original_text: body,
+        #   corrected_text: result["rewritten_text"],
+        #   mistake_type: :overall
+        #   )
+
+        # 8 個別の指摘をmistakesに1件ずつ保存する
+        #   (result["notes"] || []).each do |note|
+        #     @journal.mistakes.create!(
+        #       user_id: current_user.id,
+        #       original_text: note["original_text"],
+        #       corrected_text: note["corrected_text"],
+        #       mistake_type: note["mistake_type"],
+        #       explanation: note["explanation"]
+        #   )
+        # end
+        # 追加
+        # @overall = @journal.mistakes.find_by(mistake_type: "overall")
+        # @mistakes = @journal.mistakes.where.not(mistake_type: "overall")
+        # @english_feedback = result["english_feedback"]
+
+
 
         redirect_to @journal, notice: "添削が完了しました！"
       else

--- a/app/helpers/journal_corrections_helper.rb
+++ b/app/helpers/journal_corrections_helper.rb
@@ -1,0 +1,2 @@
+module JournalCorrectionsHelper
+end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,5 +1,6 @@
 class Journal < ApplicationRecord
   belongs_to :user
+  has_one :journal_correction, dependent: :destroy
   has_many :mistakes, dependent: :destroy
 
   validates :posted_date, presence: true

--- a/app/models/journal_correction.rb
+++ b/app/models/journal_correction.rb
@@ -1,0 +1,8 @@
+class JournalCorrection < ApplicationRecord
+  belongs_to :journal
+  belongs_to :user
+  has_many :mistakes, dependent: :destroy
+
+  validates :original_text, presence: true
+  validates :rewritten_text, presence: true
+end

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -1,6 +1,7 @@
 class Mistake < ApplicationRecord
   belongs_to :journal
   belongs_to :user
+  belongs_to :journal_correction
   validates :original_text, presence: true
 
   enum :mistake_type, { overall: 0, grammar: 1, spelling: 2, word_choice: 3, expression: 4, translation: 5 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :journals, dependent: :destroy
   has_many :mistakes, dependent: :destroy
   has_one :notification_setting, dependent: :destroy
+  has_many :journal_corrections, dependent: :destroy
 
   devise :database_authenticatable,
          :registerable,

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">JournalCorrections#index</h1>
+  <p>Find me in app/views/journal_corrections/index.html.erb</p>
+</div>

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">JournalCorrections#show</h1>
+  <p>Find me in app/views/journal_corrections/show.html.erb</p>
+</div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-bold font-title text-3xl md:text-4xl text-center font-cream-500 mb-6">
+    <h1 class="font-bold font-title text-lg md:text-4xl sm:text-2xl text-center font-cream-500 mb-6">
     My Journal
     </h1>
 
@@ -29,7 +29,7 @@
           </p>
 
           <p class="mb-3 line-clamp-2">
-              <%= journal.corrected_body %>
+              <%= journal.journal_correction&.rewritten_text %>
           </p>
           <% end %>
         <% end %>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-3 sm:px-6 md:px-10"> 
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-sans font-bold text-3xl md:text-4xl text-center mb-6"><%= t('.title') %></h1>
+    <h1 class="font-sans font-bold text-lg md:text-4xl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>
 </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -3,21 +3,32 @@
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <%# ページタイトル %>
-    <h1 class="font-sans font-bold text-3xl md:text-4xl text-center mb-6">
+    <h1 class="font-sans font-bold text-lg md:text-4xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>
 
   <%# 元の文章（日本語でもそのまま表示） %>
-    <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-      <h2 class="font-semibold mb-2">元の文章 </h2>
-        <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
+  <%# スマホ：折りたたみ表示 %>
+    <div class="sm:hidden collapse border border-cream-300 bg-forest-100 rounded-2xl p-2 mb-4">
+      <input type="checkbox" />
+      <h2 class=" collapse-title font-semibold">元の文章 </h2>
+        <div class="collapse-content border border-cream-300 bg-white rounded-2xl p-4">
         <p>
-          <%= @overall&.original_text %>
+          <%= @journal_correction&.original_text %>
         </p>
         </div>
     </div>
-    
-    <%# 添削後の英文 %>
+  <%# sm以上：通常表示 %>
+      <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
+      <h2 class="font-semibold mb-2">元の文章 </h2>
+        <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
+        <p>
+          <%= @journal_correction&.original_text %>
+        </p>
+        </div>
+    </div>
+
+    <%# 添削後の英文(全文) %>
     <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <div class="flex items-center gap-2">
         <h2 class="font-semibold mb-3">添削後の文章</h2>
@@ -25,7 +36,7 @@
       </div>
         <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
           <p>  
-          <%= @overall&.corrected_text %>
+          <%= @journal_correction.rewritten_text %>
           </p>
         </div>
     </div>
@@ -56,8 +67,39 @@
       </div>
     <% end %>
 
+    <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
+    <%# a %>
+      <h3 class="font-semibold text-base mb-2">英文の傾向</h3>
+    <% if @journal_correction.present? %>
+      <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
+    
+      
+      <div class="mb-2">  
+      <p class="font-semibold">良い点</p>
+        <% (@journal_correction.strengths || []).each do |strength|  %>
+        <p>【強み】<%= strength["point"] %></p>
+        <p>【元の文章】<%= strength["evidence"] %></p>
+        <p>【何が良かったか】<%= strength["why_it_works"] %></p>
+        <% end %>
+      </div>
+        
+        <div class="mb-2">  
+        <p class="font-semibold">間違いパターン</p>
+        <% (@journal_correction.mistake_patterns || []).each do |pattern| %>
+          <div class="mb-2">
+          <p>【パターン】<%= pattern["point"] %></p>
+          <p>【元の文章】<%= pattern["evidence"] %></p>
+          <p>【説明】<%= pattern["explanation"] %></p>
+          </div>
+        <% end %>
 
-
+      <p class="font-semibold">アドバイス</p>
+      <p><%= @journal_correction["advice"] %></p>
+    </div>
+      </div>
+  <% end %>
+  </div>
+  </div>
 
     <div class="flex mt-5 gap-5">
     <%= link_to '戻る' , journals_path, class:"btn btn-primary flex-1" %>

--- a/app/views/mistakes/index.html.erb
+++ b/app/views/mistakes/index.html.erb
@@ -1,5 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div>
-  <h1 class="font-bold text-4xl">Mistakes#index</h1>
-  <p>Find me in app/views/mistakes/index.html.erb</p>
-</div>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+  <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
+    <h1 class="font-bold font-title text-lg md:text-4xl sm:text-2xl text-center font-cream-500 mb-6">
+    My Journal
+    </h1>

--- a/app/views/mistakes/show.html.erb
+++ b/app/views/mistakes/show.html.erb
@@ -1,5 +1,8 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div>
-  <h1 class="font-bold text-4xl">Mistakes#show</h1>
-  <p>Find me in app/views/mistakes/show.html.erb</p>
-</div>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+  <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
+    <%# ページタイトル %>
+    <h1 class="font-sans font-bold text-lg md:text-4xl sm:text-2xl text-center mb-6">
+      <%= t('.title') %>
+    </h1>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
     <%= link_to "今日の日記", new_journal_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "学び", "#", class: "btn btn-ghost normal-case text-md" %>
+    <%= link_to "学び", mistakes_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md" %>
   </span>
   <% else %>
@@ -54,7 +54,7 @@
         <li><%= link_to "今日の日記", new_journal_path %></li>
         <li><%= link_to "ジャーナル一覧", journals_path %></li>
         <li><%= link_to "カレンダー", "#" %></li>
-        <li><%= link_to "学び", "#" %></li>
+        <li><%= link_to "学び", mistakes_path %></li>
         <li><%= link_to "マイページ", "#" %></li>
         <li>
           <%= link_to t('.logout'), destroy_user_session_path,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   resources :journals, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
   resources :mistakes, only: [ :index, :show, :new, :create, :destroy ]
   resource :user, only: [ :show, :edit, :update, :destroy ]
+  resources :journal_corrections, only: [ :index, :show ]
 
   # テスト用ルーティング　あとで削除する
   # get '/test500', to: 'application#test500'

--- a/db/migrate/20260425054627_create_journal_corrections.rb
+++ b/db/migrate/20260425054627_create_journal_corrections.rb
@@ -1,0 +1,15 @@
+class CreateJournalCorrections < ActiveRecord::Migration[7.2]
+  def change
+    create_table :journal_corrections do |t|
+      t.references :journal, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :original_text, null: false
+      t.text :rewritten_text, null: false
+      t.json :strengths
+      t.json :mistake_patterns
+      t.text :advice
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260425063050_add_journal_correction_to_mistakes.rb
+++ b/db/migrate/20260425063050_add_journal_correction_to_mistakes.rb
@@ -1,0 +1,5 @@
+class AddJournalCorrectionToMistakes < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :mistakes, :journal_correction, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_20_081230) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_25_063050) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "journal_corrections", force: :cascade do |t|
+    t.bigint "journal_id", null: false
+    t.bigint "user_id", null: false
+    t.text "original_text", null: false
+    t.text "rewritten_text", null: false
+    t.json "strengths"
+    t.json "mistake_patterns"
+    t.text "advice"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["journal_id"], name: "index_journal_corrections_on_journal_id"
+    t.index ["user_id"], name: "index_journal_corrections_on_user_id"
+  end
 
   create_table "journals", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -35,6 +49,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_081230) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "mistake_type"
+    t.bigint "journal_correction_id"
+    t.index ["journal_correction_id"], name: "index_mistakes_on_journal_correction_id"
     t.index ["journal_id"], name: "index_mistakes_on_journal_id"
     t.index ["user_id"], name: "index_mistakes_on_user_id"
   end
@@ -63,7 +79,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_20_081230) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "journal_corrections", "journals"
+  add_foreign_key "journal_corrections", "users"
   add_foreign_key "journals", "users"
+  add_foreign_key "mistakes", "journal_corrections"
   add_foreign_key "mistakes", "journals"
   add_foreign_key "mistakes", "users"
   add_foreign_key "notification_settings", "users"

--- a/test/controllers/journal_corrections_controller_test.rb
+++ b/test/controllers/journal_corrections_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class JournalCorrectionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+    @journal = journals(:one)
+    @journal_correction = JournalCorrection.create!(
+      journal: @journal,
+      user: @user,
+      original_text: "Original text",
+      rewritten_text: "Rewritten text"
+    )
+  end
+
+  test "should get index" do
+    get journal_corrections_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get journal_correction_url(@journal_correction)
+    assert_response :success
+  end
+end

--- a/test/fixtures/journal_corrections.yml
+++ b/test/fixtures/journal_corrections.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  journal: one
+  user: one
+  original_text: MyText
+  rewritten_text: MyText
+  strengths: 
+  mistake_patterns: 
+  advice: MyText
+
+two:
+  journal: two
+  user: two
+  original_text: MyText
+  rewritten_text: MyText
+  strengths: 
+  mistake_patterns: 
+  advice: MyText

--- a/test/models/journal_correction_test.rb
+++ b/test/models/journal_correction_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class JournalCorrectionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
  添削後の全文と個別指摘を分けて扱えるように、`journal_correctionsを追加し
全文添削文データはjournal_correctionsに保持するようにした。
（部分添削文のデータはmistakesに保持する）

## 背景
  これまでは `mistakes` テーブルに、全文添削と個別指摘が混在していました。
  学びページで扱いやすくするため、責務を分離しました。

## 変更内容
  - `journal_corrections` テーブルを追加
  - `mistakes` に `journal_correction_id` を追加
  - `Journal`, `JournalCorrection`, `Mistake`, `User` の association を追加・修正
  - `JournalsController#create` を修正し、
    - 全体添削は `journal_corrections`
    - 個別指摘は `mistakes`
    に保存するよう変更
  - `JournalsController#show` を修正し、全体添削を `journal_correction` から取得するよう変更

## 確認方法
 - ジャーナル作成時に `journal_correction` が保存されること
  - 個別指摘が `mistakes` に保存されること

## 補足
  - 本番データを考慮し、今回は追加型の変更のみ
 - 既存 `mistakes` データの整理や不要項目の削除はまだ行っていません

## 関連Issue
closes #