### PR TITLE
旧データを表示する際にエラーで画面が落ちないように対応

### DIFF
--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -36,7 +36,7 @@
       </div>
         <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
           <p>  
-          <%= @journal_correction.rewritten_text %>
+          <%= @journal_correction&.rewritten_text %>
           </p>
         </div>
     </div>
@@ -49,16 +49,16 @@
           <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
             <ol class="list-decimal list-inside">
             <% @mistakes.each do |mistake| %>
-            <li class="mb-4">
-            <span class="font-semibold">
-            <%= mistake_type_label(mistake.mistake_type) %></span>
-            <p class="text-base font-normal">  【元の文章】: <%= mistake.original_text %></p>
-            <p class="text-base font-normal">  【添削後】: <%= mistake.corrected_text %></p>
-            <p class="text-sm text-gray-600 font-normal">  ポイント: <%= mistake.explanation %></p>
+              <li class="mb-4">
+              <span class="font-semibold">
+              <%= mistake_type_label(mistake.mistake_type) %></span>
+              <p class="text-base font-normal">  【元の文章】: <%= mistake.original_text %></p>
+              <p class="text-base font-normal">  【添削後】: <%= mistake.corrected_text %></p>
+              <p class="text-sm text-gray-600 font-normal">  ポイント: <%= mistake.explanation %></p>
 
-            </li>
+              </li>
           <% end %>
-          </ol>
+            </ol>
           </div>
       </div>
     <% else %>
@@ -75,30 +75,29 @@
     
       
       <div class="mb-2">  
-      <p class="font-semibold">良い点</p>
-        <% (@journal_correction.strengths || []).each do |strength|  %>
-        <p>【強み】<%= strength["point"] %></p>
-        <p>【元の文章】<%= strength["evidence"] %></p>
-        <p>【何が良かったか】<%= strength["why_it_works"] %></p>
-        <% end %>
+        <p class="font-semibold">良い点</p>
+          <% (@journal_correction.strengths || []).each do |strength|  %>
+          <p>【強み】<%= strength["point"] %></p>
+          <p>【元の文章】<%= strength["evidence"] %></p>
+          <p>【何が良かったか】<%= strength["why_it_works"] %></p>
+          <% end %>
       </div>
         
         <div class="mb-2">  
-        <p class="font-semibold">間違いパターン</p>
-        <% (@journal_correction.mistake_patterns || []).each do |pattern| %>
-          <div class="mb-2">
-          <p>【パターン】<%= pattern["point"] %></p>
-          <p>【元の文章】<%= pattern["evidence"] %></p>
-          <p>【説明】<%= pattern["explanation"] %></p>
-          </div>
-        <% end %>
+          <p class="font-semibold">間違いパターン</p>
+          <% (@journal_correction.mistake_patterns || []).each do |pattern| %>
+            <div class="mb-2">
+            <p>【パターン】<%= pattern["point"] %></p>
+            <p>【元の文章】<%= pattern["evidence"] %></p>
+            <p>【説明】<%= pattern["explanation"] %></p>
+            </div>
+          <% end %>
 
-      <p class="font-semibold">アドバイス</p>
-      <p><%= @journal_correction["advice"] %></p>
+        <p class="font-semibold">アドバイス</p>
+        <p><%= @journal_correction["advice"] %></p>
+        </div>
     </div>
-      </div>
   <% end %>
-  </div>
   </div>
 
     <div class="flex mt-5 gap-5">


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
 旧データのジャーナル詳細画面表示時に、エラーで画面が落ちていたため修正しました。

## 背景
 2026/4/25 以前に作成されたジャーナルには `journal_correction` が存在しないデータがあります。
 その状態で `journal#show` を開くと、`rewritten_text` を参照する箇所で `NoMethodError` が発生していました。

## 変更内容
ジャーナル詳細画面の添削後全文を表示する箇所を、以下のように修正しました。
  - 修正前
    `<%= @journal_correction.rewritten_text %>`

  - 修正後
    `<%= @journal_correction&.rewritten_text %>`

## 確認方法
  - 2026/4/25 以前に作成したジャーナル詳細画面を開く
  - エラーにならず詳細画面が表示されることを確認する

## 影響範囲
2026/4/25以前に作成したジャーナル詳細画面
（過去作成したデータが反映されなくなっています。）

## 関連Issue
closes #