### PR TITLE
fix home#index 

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@ class HomeController < ApplicationController
 
   def index
     # @journals = current_user.journals.order(posted_date: :desc).limit(3)
-    @journals = current_user.journals.includes(:mistakes).order(posted_date: :desc).limit(3)
+    @journals = current_user.journals.includes(:mistakes, :journal_correction).order(posted_date: :desc).limit(3)
     @monthly_count = current_user.journals.where(posted_date: Date.current.beginning_of_month..Date.current.end_of_month).count
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -45,7 +45,7 @@
             </h4> -->
     
             <p class="text-ink mb-3 line-clamp-2">
-              <%= journal.corrected_body %>
+              <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           
             <%= link_to journal_path(journal), class: "btn btn-sm btn-outline" do %>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -9,17 +9,19 @@
 
   <%# 元の文章（日本語でもそのまま表示） %>
   <%# スマホ：折りたたみ表示 %>
-    <div class="sm:hidden collapse border border-cream-300 bg-forest-100 rounded-2xl p-2 mb-4">
+    <div class="md:hidden collapse collapse-arrow border border-cream-300 bg-forest-100 rounded-2xl mb-4">
       <input type="checkbox" />
-      <h2 class=" collapse-title font-semibold">元の文章 </h2>
-        <div class="collapse-content border border-cream-300 bg-white rounded-2xl p-4">
-        <p>
-          <%= @journal_correction&.original_text %>
-        </p>
+      <h2 class="collapse-title font-semibold pr-10">元の文章を表示</h2>
+      <div class="collapse-content">
+        <div class="border border-cream-300 bg-white rounded-2xl p-4">
+          <p>
+            <%= @journal_correction&.original_text %>
+          </p>
         </div>
+      </div>
     </div>
-  <%# sm以上：通常表示 %>
-      <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
+  <%# md以上：通常表示 %>
+      <div class="hidden md:block border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <h2 class="font-semibold mb-2">元の文章 </h2>
         <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
         <p>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
- ログイン後のホーム画面で、添削後の文章が表示されるように修正しました。
- スマホ表示のジャーナリング詳細画面で「元の文章」が重複して表示されていたため、
PC用の「元の文章」をスマホでは非表示にしました。

## 背景
- 添削後の全文をmistakesテーブルではなくjournal_correctionsにデータを保持することにしたため、
データの参照をmistakesからjournal_correctionsに変更した。

- スマホでジャーナリング詳細画面を表示した際に、
PC用とスマホ用の「元の文章」が両方表示されていたため、スマホではスマホ用の表示のみになるように調整しました。

## 変更内容
  - `HomeController`
    - `current_user.journals` の取得時に `journal_correction` を eager loading するように変更
    - 変更前:
      ```rb
      current_user.journals.includes(:mistakes)
      ```
    - 変更後:
      ```rb
      current_user.journals.includes(:mistakes, :journal_correction)
      ```

  - `app/views/home/index.html.erb`
    - 添削後の文章表示で `mistake` のデータを参照していた箇所を、journal_correction.rewritten_text` を参照するように変更
    - `journal_correction` が存在しない場合は、元の本文 `journal.body` を表示するようにしました
      ```erb
      <%= journal.journal_correction&.rewritten_text || journal.body %>

  - `app/views/jounals/show.html.erb`
    - スマホ表示時にPC用の「元の文章」が表示されないように修正
    - スマホではスマホ用の「元の文章」のみ表示されるように調整


## 確認方法
  - ログイン後のホーム画面で、添削後の文章が表示されること
  - 添削データがない場合は、元の本文が表示されること
  - スマホ表示のジャーナリング詳細画面で「元の文章」が重複表示されないこと
  - PC表示のジャーナリング詳細画面の見た目に影響がないこと

## 関連Issue
closes #