### PR TITLE
feat:学び一覧画面の作成

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -2,7 +2,12 @@ class JournalCorrectionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @journal_corrections = current_user.journal_corrections.includes(:journal, :mistakes).order(created_at: :desc)
+    @journal_corrections = current_user
+                           .journal_corrections
+                           .includes(:journal, :mistakes)
+                           .joins(:journal)
+                           .where(journals: {posted_date: Date.current.all_month })
+                           .order("journals.posted_date DESC")
   end
 
   def show

--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -6,7 +6,7 @@ class JournalCorrectionsController < ApplicationController
                            .journal_corrections
                            .includes(:journal, :mistakes)
                            .joins(:journal)
-                           .where(journals: {posted_date: Date.current.all_month })
+                           .where(journals: { posted_date: Date.current.all_month })
                            .order("journals.posted_date DESC")
   end
 

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,4 +1,36 @@
-<div>
-  <h1 class="font-bold text-4xl">JournalCorrections#index</h1>
-  <p>Find me in app/views/journal_corrections/index.html.erb</p>
+<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+  <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+    <h1 class="font-semibold font-sans text-lg md:text-4xl sm:text-2xl text-center mb-6">
+    学び一覧
+    </h1>
+
+    <% if @journal_corrections.any? %>
+      <div class="space-y-2">
+      <%# journal_correctionsをループ %>
+      <% @journal_corrections.each do |journal_correction| %>
+
+        <%# 1件ずつ枠で囲む %>
+        <%= link_to journal_correction_path(journal_correction),
+            class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
+        <p class="font-bold text-cream-500 mb-3">
+        <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>
+        </p>
+
+        <p class="mb-3 line-clamp-2">
+          <%= journal_correction.rewritten_text %>
+
+        </p>
+        <% end %>
+      <% end %>
+      </div>
+    <% else %>
+      <div role="alert" class="alert alert-info alert-soft">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span>まだジャーナリングがありません。最初のジャーナリングを書いてみましょう！</span>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -29,7 +29,7 @@
           </p>
 
           <p class="mb-3 line-clamp-2">
-              <%= journal.journal_correction&.rewritten_text %>
+              <%= journal.journal_correction&.rewritten_text || journal.body %>
           </p>
           <% end %>
         <% end %>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-3 sm:px-6 md:px-10"> 
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-sans font-bold text-lg md:text-4xl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
+    <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,7 +13,7 @@
     <%= link_to "今日の日記", new_journal_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "学び", mistakes_path, class: "btn btn-ghost normal-case text-md" %>
+    <%= link_to "学び", journal_corrections_path, class: "btn btn-ghost normal-case text-md" %>
     <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md" %>
   </span>
   <% else %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -23,10 +23,16 @@ ja:
     new:
       title: ジャーナリング作成
     show:
-      title: 添削結果
+      title: ジャーナル添削結果
+  journal_corrections:
+    index:
+      title: 学び一覧
+    show:
+      title: 学び詳細
   shared:
     header:
       login: ログイン
       logout: ログアウト
       register: 新規登録
+
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
学び一覧画面を作成しました
ヘッダーの「学び」を押下すると学び一覧画面に遷移するようにしました。

## 背景
  添削結果と個別の指摘を、あとから見返せる画面が必要だったためです。
  これまではヘッダーに「学び」への導線がなく、添削済みの内容を一覧で確認できる画面もありませんでした。

## 変更内容
  - `app/views/shared/_header.html.erb`
「学び」を押下すると、学び一覧画面(‘journal_corrections_path‘)に遷移するようにしました

  - `JournalCorrectionsController#index`
    - ログイン中のユーザーに紐づく `journal_corrections` を取得するようにしました
    - 関連する `journal` と `mistakes` もあわせて取得するようにしました
  
  - `app/views/journal_corrections/index.html.erb`
    - 学び一覧画面を作成
    - 各 `journal_correction` をカード形式で表示
    - 日付と添削内容の一部を表示
    - 各カードから学び詳細画面へ遷移できるようにしました
    - 

## 確認方法
  - ヘッダーの「学び」を押下すると、学び一覧画面に遷移すること
  - 学び一覧画面に、ログイン中のユーザーの `journal_corrections` が表示されること
  - 各カードを押下すると、対象の学び詳細画面に遷移すること

## 関連Issue
closes #106 