### PR TITLE
feat:学びページ詳細画面作成

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -11,6 +11,9 @@ class JournalCorrectionsController < ApplicationController
   end
 
   def show
-    @journal_correction = current_user.journal_corrections.includes(:mistakes, :journal).find(params[:id])
+    @journal_correction = current_user
+                          .journal_corrections
+                          .includes(:mistakes, :journal)
+                          .find(params[:id])
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-title font-bold text-2xl sm:text-3xl md:text-4xl mb-6 leading-tight">
     <%= current_user.name %>'s Journal

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     <h1 class="font-semibold font-sans text-lg md:text-4xl sm:text-2xl text-center mb-6">
     学び一覧
     </h1>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-bold font-title text-lg md:text-4xl sm:text-2xl text-center font-cream-500 mb-6">
     My Journal

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-3 sm:px-6 md:px-10"> 
-   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -1,14 +1,15 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <%# ページタイトル %>
-    <h1 class="font-sans font-bold text-lg md:text-4xl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>
 
   <%# 元の文章（日本語でもそのまま表示） %>
   <%# スマホ：折りたたみ表示 %>
+    <div class="font-semibold mb-2"><%= @journal.posted_date.strftime("%Y/%m/%d") %></div>
     <div class="md:hidden collapse collapse-arrow border border-cream-300 bg-forest-100 rounded-2xl mb-4">
       <input type="checkbox" />
       <h2 class="collapse-title font-semibold pr-10">元の文章を表示</h2>
@@ -29,12 +30,17 @@
         </p>
         </div>
     </div>
+  
+    <% if @journal_correction.present? %>
+      <%= render "shared/mistakes_list", mistakes: @mistakes, show_original_text: true, journal: @journal %>
+    <% end %>
 
     <%# 添削後の英文(全文) %>
-    <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
+    <!--<div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <div class="flex items-center gap-2">
         <h2 class="font-semibold mb-3">添削後の文章</h2>
-        <span class="badge badge-ghost mb-3 p-3">添削トーン：<%= t("activerecord.attributes.journal.tones.#{@journal.tone}") %></span>
+        <span class="badge badge-soft badge-success text-white mb-3 p-3">
+        添削トーン：<%= t("activerecord.attributes.journal.tones.#{@journal.tone}") %></span>
       </div>
         <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
           <p>  
@@ -69,38 +75,44 @@
       </div>
     <% end %>
 
-    <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-    <%# a %>
-      <h3 class="font-semibold text-base mb-2">英文の傾向</h3>
-    <% if @journal_correction.present? %>
-      <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
-    
-      
-      <div class="mb-2">  
-        <p class="font-semibold">良い点</p>
-          <% (@journal_correction.strengths || []).each do |strength|  %>
-          <p>【強み】<%= strength["point"] %></p>
-          <p>【元の文章】<%= strength["evidence"] %></p>
-          <p>【何が良かったか】<%= strength["why_it_works"] %></p>
-          <% end %>
-      </div>
-        
-        <div class="mb-2">  
-          <p class="font-semibold">間違いパターン</p>
-          <% (@journal_correction.mistake_patterns || []).each do |pattern| %>
-            <div class="mb-2">
-            <p>【パターン】<%= pattern["point"] %></p>
-            <p>【元の文章】<%= pattern["evidence"] %></p>
-            <p>【説明】<%= pattern["explanation"] %></p>
-            </div>
-          <% end %>
+    <%# strengths に データがある場合のみ「英文の傾向」ブロックを表示 %>
+    <% if @journal_correction&.strengths.present? %>
 
-        <p class="font-semibold">アドバイス</p>
-        <p><%= @journal_correction["advice"] %></p>
+      <%# 外側のカード %>
+      <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
+        <h3 class="font-semibold text-base mb-2">英文の傾向</h3>
+        
+  
+        <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
+          <div class="mb-2">  
+            <p class="font-semibold">良い点</p>
+              <% (@journal_correction.strengths || []).each do |strength|  %>
+              <p>【強み】<%= strength["point"] %></p>
+              <p>【元の文章】<%= strength["evidence"] %></p>
+              <p>【何が良かったか】<%= strength["why_it_works"] %></p>
+              <% end %>
+          </div>
+
+            
+
+          <div class="mb-2">  
+            <p class="font-semibold">間違いパターン</p>
+            <% (@journal_correction.mistake_patterns || []).each do |pattern| %>
+              <div class="mb-2">
+              <p>【パターン】<%= pattern["point"] %></p>
+              <p>【元の文章】<%= pattern["evidence"] %></p>
+              <p>【説明】<%= pattern["explanation"] %></p>
+              </div>
+            <% end %>
+          </div>
+  
+
+          <p class="font-semibold">アドバイス</p>
+          <p><%= @journal_correction["advice"] %></p>
         </div>
-    </div>
-  <% end %>
-  </div>
+      </div>
+    <% end %> -->
+     
 
     <div class="flex mt-5 gap-5">
     <%= link_to '戻る' , journals_path, class:"btn btn-primary flex-1" %>

--- a/app/views/mistakes/show.html.erb
+++ b/app/views/mistakes/show.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <%# ページタイトル %>
     <h1 class="font-sans font-bold text-lg md:text-4xl sm:text-2xl text-center mb-6">

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,14 +1,12 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<!-- <%= content_for(:title, t('.title', default: APP_NAME)) %> 
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     
     <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>
-    
-    <div class="font-semibold mb-2"> <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %></div>
-    <%= render "shared/mistakes_list", mistakes: @journal_correction.mistakes, show_original_text: false %>
-    <!--<div class="font-semibold mb-2"> <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %> </div>
+
+    <div class="font-semibold mb-2"> <%# @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %> </div>-->
     <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <div class="flex items-center gap-2">
         <h2 class="font-semibold mb-3">添削後の文章</h2>
@@ -34,9 +32,9 @@
                 <span class="font-semibold">
                   <%= mistake_type_label(mistake.mistake_type) %>
                 </span>
-
-                <p class="text-base font-normal">【添削後】：<%= mistake.corrected_text %></p>
-                <p class="text-base font-normal">ポイント： <%= mistake.explanation %></p>
+                <p class="text-base bg-gray-100 px-3 py-2 text-gray-600 mb-1">  【元の文章】: <%= mistake.original_text %></p>
+                <p class="text-base bg-sage-50 border-l-2 border-forest-200 px-3 py-2">【添削後】：<%= mistake.corrected_text %></p>
+                <p class="text-base">ポイント： <%= mistake.explanation %></p>
               </li>
             <% end %>
           </ol>
@@ -51,23 +49,25 @@
     <%# 外側のカード %>
     <% if @journal_correction&.strengths.present? %>
       <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-2">
-        <h3 class="font-semibold text-base mb-2">英文の傾向</h3> -->
+        <h3 class="font-semibold text-base mb-2">英文の傾向</h3>
        
 
         <%# 内側の白部分 %>
-          <!-- <div class="mb-2">
+        <!--<div class="border border-gray-100 bg-white rounded-2xl p-4 mb-2"> -->
+          <div class="mb-2">
           <p class="badge badge-success text-white p-3 mb-2">良い点</p>
             
             <% (@journal_correction.strengths || []).each do |strength| %>
               <div class="bg-white rounded-2xl p-4 mb-2">
                 <p class="font-semibold"><%= strength["point"] %></p>
-                <p>【元の文章】<%= strength["evidence"] %></p>
+                <p class="bg-sage-50 border-l-2 border-forest-200 px-3 py-2">【元の文章】<%= strength["evidence"] %></p>
                 <p>【良かった点】<%= strength["why_it_works"] %></p>
               </div>
             <% end %>
             
           </div>
 
+         <% if @journal_correction&.mistake_patterns.present? %>
           <hr class="border-forest-300 mb-2">
           
           <div class="mb-2">
@@ -76,11 +76,13 @@
             <% (@journal_correction.mistake_patterns || []).each do |pattern| %> 
               <div class="bg-white rounded-2xl p-3 mb-2">
                 <p class="font-semibold"><%= pattern["point"] %></p>
-                <p>【元の文章】<%= pattern["evidence"] %></p>
+                <p class="bg-gray-100 px-3 py-2 text-gray-600">【元の文章】<%= pattern["evidence"] %></p>
                 <p>【説明】<%= pattern["explanation"] %></p>
               </div>
             <% end %>
           </div>
+          <% end %>
+          <!--</div> -->
           
           <hr class="border-forest-300 mb-2">
 
@@ -90,10 +92,9 @@
               <%= @journal_correction["advice"] %>
             </div>
           </div>
-
      
       </div>
-    <% end %> -->
+    <% end %>
 
-  </div>
-</div>
+ <!-- </div>
+</div> -->


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
学び詳細画面を作成しました。

## 変更内容
  - `journal_corrections#show` で添削結果の詳細を表示
  - 添削後の文章、今回の学び、英文の傾向、アドバイスを表示
  - `shared/_mistakes_list.html.erb` を追加し、学び表示部分を共通化
  - `journals#show` でも共通partialを読み込むように変更
  - 画面幅を `max-w-3xl` から `max-w-4xl` に調整

## 確認内容
  - 学び一覧画面から詳細画面へ遷移できること
  - 学び詳細画面で以下が表示されること
    - 投稿日
    - 添削後の文章
    - 今回の学び
    - 英文の傾向
    - アドバイス
  - ジャーナル詳細画面でも共通partialの表示が崩れないこと

## 補足
  `shared/_mistakes_list.html.erb` は、`journal_corrections#show` と `journals#show` の両方で使う想定で追加しています。

## 関連Issue
closes #112 