### PR TITLE
fix 英語添削プロンプトの修正

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -37,29 +37,25 @@ class JournalsController < ApplicationController
     # 2 AIへの指示(プロンプト)を作成する
 
     prompt = <<~PROMPT
-    You are a bilingual Japanese-English writing coach and a native speaker of American English.
-    The user may write in Japanese or English.
-
+    You are a bilingual Japanese-English writing teacher and correction coach who helps learners write natural American English and understand grammar clearly in Japanese.
     Your job is to REWRITE the user's message into natural, emotionally authentic American English without changing the original meaning.
+    After each grammar correction, teach grammar formula / pattern and 2 natural American English examples and a tip.
+    If the mistake is related to tense, present perfect, prepositions, gerunds, infinitives, or word order:
+
+    Always explain:
+    1. Basic grammar rule
+    2. Why it applies here
+    3. Corrected example
+    4. Short learning tip
+    If the user uses unnatural phrasing, explain the more natural expression.
 
     ====================
-    REWRITE RULES
+    TASK
     ====================
-    Important:
-    - Do NOT translate literally.
-    - Do NOT preserve awkward wording.
-    - Preserve the original meaning, emotional nuance, and timeline.
-    - Do not over-specify what is only implied.
-    - If the original text is vague, keep it naturally vague.
-    - Do not move motives from one event to another.
-    - Rewrite into natural American English a real person would use.
-    - Understand Japanese nuance deeply before rewriting into natural American English.
-    - Preserve the original meaning, emotional nuance, and timeline.
-    - If the text is in Japanese, follow the flow of the original Japanese writing and rewrite the intended meaning into natural American English.
+    Rewrite the user's text into natural American English, then provide corrections and feedback.
 
-    #{' '}
-    Tone:
-    polite:
+    Tone: #{tone}
+    - polite:#{'  '}
     Calm, thoughtful, emotionally mature natural American English.
     Kind, steady, and respectful.
     Slightly polished, but still simple and human.
@@ -68,123 +64,66 @@ class JournalsController < ApplicationController
     Longer smooth sentences are okay.
     Reserved emotional tone.
 
-    standard:
+    - standard:
     Warm, natural everyday American English.
     Honest, balanced, believable.
     Like a real native American writing privately.
     Default natural tone.
 
-    casual:
+    - casual:
     Warm, relaxed, conversational natural American English.
     More spontaneous and emotionally close.
     Use simple wording and natural flow.
     Simple wording should not oversimplify meaning.
     More immediate and human.
 
-    Current tone: #{tone}
+    The user may write in Japanese or English.
+
+    ====================
+    REWRITE RULES
+    ====================
+    Important:
+    - Preserve the original meaning, emotional nuance, and timeline.
+    - Do NOT translate literally or preserve awkward wording
+    - Do not over-specify what is only implied.
+    - If the original text is vague, keep it naturally vague.
+    - Do not over-specify implied information
+    - Rewrite into natural American English a real person would use.
+    - Understand Japanese nuance deeply before rewriting into natural American English.
+    - If the text is in Japanese, follow the flow of the original Japanese writing and rewrite the intended meaning into natural American English.
+
+
     ====================
     CORRECTION RULES
     ====================
-    - Return all important corrections found in the text.
-    - Do not skip clear mistakes.
-
-    For each issue, use one mistake_type only:
-    grammar
-    spelling
-    word_choice
-    expression
-    translation
-
-    For every note, return:
+    For each mistake, provide:
     - original_text
     - corrected_text
-    - mistake_type
-    - explanation (Japanese)
+    - mistake_type: grammar | spelling | word_choice | expression | translation
+    - explanation (in Japanese)
 
-    GRAMMAR EXPLANATIONS:
-    - Be practical and beginner-friendly.
-    - Explain what was wrong in THIS sentence.
-    - Show how to write it correctly next time.
-    - Prefer reusable patterns over abstract grammar labels.
-    - Explanations must help the learner write the sentence correctly next time.
-
-    Examples:
-    go to + place
-    want to + verb
-    a + singular noun
-    yesterday + past tense
-    He/She/It + verb-s
-
-    Good example:
-    「前置詞：『部屋へ行く』は go to + place を使います。」
-    「時制：yesterday があるので過去形 went を使います。」
-
-    OTHER TYPES:
-    - Keep explanations short and clear.
-    - Focus on what sounds natural and how to improve.
-
-    - Use this format:
-    「ルール名：今回なぜ直すのか。どう考えればよいか。」
-      Example: 「時制の誤り：yesterday があるので、現在形ではなく過去形 went を使います。」
-      Example: 「主語と動詞の不一致：主語が三人称単数のときは動詞に -s が必要です。」
-    - For other mistake types, explain briefly in Japanese.
-    - Avoid overexplaining non-grammar issues.
+    Grammar explanations should be practical:
+    Explain the reusable grammar rule behind each mistake or show common and frequently used collocation patterns not only the correction.
+    ✓ Good: 「前置詞：『部屋へ行く』は go to + place を使います」具体例を出し、使う組み合わせを提示する。
+    ✓ Good: 「基本ルール：when it comes to + 名詞 / 動名詞」この表現の to は不定詞ではなく前置詞です。そのため後ろに動詞の原形 write は置けず、動名詞 writing を使います。
+    ✗ Bad: 「文法的に誤りがあります」
 
     ====================
-    ENGLISH FEEDBACK
+    ENGLISH FEEDBACK RULES
     ====================
-    Based only on THIS text, return:
+    Analyze ONLY English usage. Do NOT comment on emotions or story content.
 
-    - strengths (what user does well)
-    - mistake_patterns (repeated tendencies)
-    - advice (one short tip)
+    Focus on:
+    - Grammar tendencies
+    - Common mistake patterns
+    - Vocabulary usage
+    - Sentence structure
 
-    Be honest, helpful, supportive.
+    Be specific to THIS text. Avoid generic comments.
+    ✓ Good: 「前置詞が抜けやすいです」「動名詞：'come to + 名詞 / 動名詞' の場合、'to' の後には動詞の原形ではなく、動名詞を使います。」
+    ✗ Bad: 「気持ちがよく伝わります」
 
-    ====================
-    INPUT
-    ====================
-      Input text:
-      "#{body}"
-
-    ====================
-    OUTPUT JSON ONLY
-    ====================
-      Do not omit any keys.
-      Return Only this JSON format
-      Use exactly this structure:
-      {
-        "rewritten_text": "添削後の英文をここに",
-        "notes":[
-          {
-            "original_text": "元の文章",
-            "corrected_text": "正しい表現",
-            "mistake_type": "grammar or spelling or word_choice or expression or translation",
-            "explanation": "日本語で簡潔な説明"
-          }
-        ],
-      "english_feedback": {
-        "strengths": [
-        "point": "英語表現上のよかった点",
-        "evidence": "元の文または修正文の具体例",
-        "why_it_works": "なぜよいのかを日本語で1文"
-        ],
-        "mistake_patterns": [
-          "point": "この文で見られた英語の傾向や弱点を分かりやすく。",
-          "evidence": "元の文の具体例",
-          "explanation": "このミスがなぜ起きているか、どう直すべきかを日本語で1〜2文。前置詞であればどうすべきか、時制ならどうすべきかなど具体的に"
-        ],
-        "advice": {
-          "point": "この文から言える短い改善アドバイス",
-          "evidence": "どのミスを根拠にしているか"
-        }
-       }
-      }
-
-      ====================
-      ENGLISH FEEDBACK
-      ====================
-      Analyze the user's ENGLISH usage only.
+     Analyze the user's ENGLISH usage only.
       Do NOT comment on emotions, story content, personality, or life situation.
       Focus only on English writing.
       Focus only on:
@@ -198,18 +137,22 @@ class JournalsController < ApplicationController
       Return:
       - strengths = what the user does well in English
       - mistake_patterns = repeated English mistakes or weak areas
-      - advice = one short practical study tip in Japanese based only on the mistakes in this text
+      - native_phrases = provide expressions native speakers often use, and phrases commonly used related to the user's topic and emotions.
+        Do not return generic comfort phrases such as:
+        take it easy
+        no worries
+        stay positive
+        you got this
+
       - If there is not enough evidence, return an empty array.
       - Do not make the feedback overly short.
       - Each explanation should be concrete and specific to this text.
       - Strengths must describe specific English skills shown in THIS text.
       - Avoid generic comments.
 
-
       Examples of good strengths:
       - 状況説明の語順が自然です
       - 会話で使える自然な表現を選べています
-      - 文の流れが自然です
 
       Examples of good mistake_patterns:
       - 前置詞が抜けやすいです
@@ -225,11 +168,68 @@ class JournalsController < ApplicationController
       - 感情を英語で表現できています
       - 文の流れが自然です
 
-      Examples of advice:
-      - 移動を表す go は go to + 場所 を意識すると自然になります。
+      Examples of native_phrases:
+      provide practical native expressions related to the exact situation and meaning described in the journal.
+    #{' '}
+      1. The meaning in Japanese
+      2. When native speakers use it (context / situation)
+      3. Short nuance explanation
+      4. One natural example sentence
+      5. Why it matches the user's journal topic
+
+      Teach phrases in a practical learning style.
 
       Do NOT analyze personality or emotional content.
       Use only this text as evidence.
+
+    ====================
+    INPUT
+    ====================
+      Input text:
+      "#{body}"
+
+    ====================
+    OUTPUT JSON ONLY
+    ====================
+      Do not omit any keys.
+      Return ONLY valid JSON matching this exact structure:
+      {
+        "rewritten_text": "text (required)",
+        "notes":[
+          {
+            "original_text": "string (required)",
+            "corrected_text": "string (required)",
+            "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
+            "explanation": "text in Japanese (required)"
+          }
+        ],
+      "english_feedback": {
+        "strengths": [
+         {
+        "point": "英語表現上のよかった点",
+        "evidence": "元の文の具体例",
+        "why_it_works": "なぜよいのかを日本語で1文"
+         }
+        ],
+        "mistake_patterns": [
+          {#{' '}
+          "point": "この文で見られた英語の傾向や弱点を分かりやすく。",
+          "evidence": "元の文の具体例",
+          "explanation": "このミスがなぜ起きているか、どう直すべきかを日本語で1〜2文。前置詞であればどうすべきか、時制ならどうすべきかなど具体的に"
+          }
+         ],
+        "native_phrases": [
+            {
+              "phrase": "ネイティブがよく使うフレーズ",
+              "meaning": "日本語の意味",
+              "when_to_use": "使用する場面",
+              "example": "I want to change, but I'm not sure what's holding me back.",
+              "why_it_matches": "なぜこの文脈に合うのか"
+            }
+          ]
+        }
+       }
+      }
 
       If the input contains Japanese text, classify all rewriting choices as "translation" type.
       For each translation note, explain in Japanese why the specific English word or phrase was chosen to express the original Japanese nuance.
@@ -272,7 +272,7 @@ class JournalsController < ApplicationController
           rewritten_text: result["rewritten_text"],
           strengths: result.dig("english_feedback", "strengths"),
           mistake_patterns: result.dig("english_feedback", "mistake_patterns"),
-          advice: result.dig("english_feedback", "advice", "point")
+          native_phrases: result.dig("english_feedback", "native_phrases")
         )
 
         (result["notes"] || []).each do |note|

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -137,7 +137,13 @@ class JournalsController < ApplicationController
       Return:
       - strengths = what the user does well in English
       - mistake_patterns = repeated English mistakes or weak areas
-      - native_phrases = provide expressions native speakers often use, and phrases commonly used related to the user's topic and emotions.
+     - native_phrases:
+        -provide 2 to 3 practical expressions native speakers naturally useto express the same feeling or situation in this journal.Do not return generic motivational phrases.
+        - native_phrases must be based ONLY on meanings explicitly written in the journal.
+        - Return at least 2 native_phrases, and give basic grammar rule.
+        - Return no more than 3 native_phrases.
+        - Each phrase must be useful in a different situation or nuance.
+        - Do not return duplicate or very similar phrases.
         Do not return generic comfort phrases such as:
         take it easy
         no worries
@@ -220,11 +226,11 @@ class JournalsController < ApplicationController
          ],
         "native_phrases": [
             {
-              "phrase": "ネイティブがよく使うフレーズ",
+              "phrase": "native phrase and basic grammar rule",
               "meaning": "日本語の意味",
-              "when_to_use": "使用する場面",
+              "corrected_text": "添削後の文",
               "example": "よく使う例文",
-              "why_it_matches": "なぜこの文脈に合うのか"
+              "example2": "よく使う例文"
             }
           ]
         }

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -223,7 +223,7 @@ class JournalsController < ApplicationController
               "phrase": "ネイティブがよく使うフレーズ",
               "meaning": "日本語の意味",
               "when_to_use": "使用する場面",
-              "example": "I want to change, but I'm not sure what's holding me back.",
+              "example": "よく使う例文",
               "why_it_matches": "なぜこの文脈に合うのか"
             }
           ]

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -6,3 +6,4 @@ class Mistake < ApplicationRecord
 
   enum :mistake_type, { overall: 0, grammar: 1, spelling: 2, word_choice: 3, expression: 4, translation: 5 }
 end
+# tense, present perfect, prepositions, gerunds, infinitives, or word order

--- a/app/views/devise/shared/_auth_wrapper.html.erb
+++ b/app/views/devise/shared/_auth_wrapper.html.erb
@@ -10,7 +10,8 @@
       <!-- <h1 class="font-cormorant text-4xl font-bold text-ink">Capture Your Day</h1> -->
 
       
-      <p class="text-base sm:text-lg md:text-xl text-ink-muted mt-4"> Write your thoughts. Track your growth. </p>
+      <!--<p class="text-base sm:text-lg md:text-xl text-ink-muted mt-4"> Write your thoughts. Track your growth. </p>-->
+      <p class="text-base sm:text-lg md:text-xl text-ink-muted mt-4"> Express your thoughts. Expand your world. </p>
     </div>
     <div class="bg-white border border-sage-100 rounded-3xl p-10 shadow-sm">
     <!-- <div class="bg-washi rounded-3xl border border-washi-border shadow-md p-8"> -->

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -93,9 +93,9 @@
             <div class="bg-white rounded-2xl p-3 mb-2">
               <p>【表現】<%= phrase["phrase"] %></p>
               <p>【意味】<%= phrase["meaning"] %></p>
-              <p>【使う場面】<%= phrase["when_to_use"] %></p>
+              <p>【今回の文】<%= phrase["corrected_text"] %></p>
               <p>【例文】<%= phrase["example"] %></p>
-              <p>【なぜこの表現】<%= phrase["why_it_matches"] %></p>
+              <p>【例文2】<%= phrase["example2"] %></p>
             </div>
             <% end %>
           </div>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -87,12 +87,19 @@
           <hr class="border-forest-300 mb-2">
 
           <div class="mb-2">
-            <p class="badge badge-warning p-3 mb-2">アドバイス</p>
+            <p class="badge badge-warning p-3 mb-2">ネイティブがよく使う表現</p>
+            
+            <% @journal_correction.native_phrases.each do |phrase| %>
             <div class="bg-white rounded-2xl p-3 mb-2">
-              <%= @journal_correction["advice"] %>
+              <p>【表現】<%= phrase["phrase"] %></p>
+              <p>【意味】<%= phrase["meaning"] %></p>
+              <p>【使う場面】<%= phrase["when_to_use"] %></p>
+              <p>【例文】<%= phrase["example"] %></p>
+              <p>【なぜこの表現】<%= phrase["why_it_matches"] %></p>
             </div>
+            <% end %>
           </div>
-     
+
       </div>
     <% end %>
 

--- a/db/migrate/20260428115420_add_native_phrases_to_journal_corrections.rb
+++ b/db/migrate/20260428115420_add_native_phrases_to_journal_corrections.rb
@@ -1,0 +1,5 @@
+class AddNativePhrasesToJournalCorrections < ActiveRecord::Migration[7.2]
+  def change
+    add_column :journal_corrections, :native_phrases, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_25_063050) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_28_115420) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -24,6 +24,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_25_063050) do
     t.text "advice"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "native_phrases"
     t.index ["journal_id"], name: "index_journal_corrections_on_journal_id"
     t.index ["user_id"], name: "index_journal_corrections_on_user_id"
   end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
英語添削時のAIプロンプトを修正し、添削内容がより具体的になるように調整しました。
これまで `advice` として扱っていたフィードバックを、ネイティブがよく使う表現として `native_phrases` に変更しました。

## 変更内容
  - 添削プロンプトの修正
  - `advice` から `native_phrases` への返却構造変更
  - `journal_corrections.native_phrases` カラム追加
  - ネイティブ表現の表示追加

## 確認方法
  - ジャーナル作成時にAI添削が実行されること
  - `journal_corrections.native_phrases` にAIの返答が保存されること
  - 添削結果画面でネイティブ表現が項目ごとに表示されること

## 関連Issue
closes #115 