### PR TITLE
mistakesテーブルにlearning_pointsを追加

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -7,7 +7,7 @@ class JournalCorrectionsController < ApplicationController
                            .includes(:journal, :mistakes)
                            .joins(:journal)
                            .where(journals: { posted_date: Date.current.all_month })
-                           .order("journals.posted_date DESC")
+                           .order("journals.posted_date DESC, journal_corrections.journal_id DESC")
   end
 
   def show

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -41,7 +41,7 @@ class JournalsController < ApplicationController
     prompt = <<~PROMPT
     You are a bilingual Japanese-English writing teacher and correction coach who helps learners write natural American English and understand grammar clearly in Japanese.
     Your job is to REWRITE the user's message into natural, emotionally authentic American English without changing the original meaning.
-    After each grammar correction, teach grammar formula / pattern and 2 natural American English examples and a tip.
+    After each grammar correction, teach grammar formula / pattern and a tip.
     If the mistake is related to tense, present perfect, prepositions, gerunds, infinitives, or word order:
 
     Always explain:
@@ -94,12 +94,11 @@ class JournalsController < ApplicationController
     - Understand Japanese nuance deeply before rewriting into natural American English.
     - If the text is in Japanese, follow the flow of the original Japanese writing and rewrite the intended meaning into natural American English.
 
-
     ====================
     CORRECTION RULES
     ====================
-    - Return 3 to 5 notes for short input.
-    - Return 5 to 10 notes for longer input when there are enough useful learning points.
+    - Return 5 to 7 notes for short input.
+    - Return 6 to 10 notes for longer input when there are enough useful learning points.
     Do not only return the most serious mistakes.
     Include useful learning points from grammar, word choice, spelling, sentence structure, and natural expression.
     Each note should cover one specific learning point.
@@ -109,6 +108,16 @@ class JournalsController < ApplicationController
     - corrected_text
     - mistake_type: grammar | spelling | word_choice | expression | translation
     - explanation (in Japanese)
+      First explain what is grammatically missing or unnatural in the original text.
+      Then explain the reusable English pattern used in the correction.
+      Avoid explanations that only describe sentence flow, tone, or readability.
+    - learning_points:
+      - label: short Japanese label for the learning point
+      - pattern: 
+        reusable English grammar pattern or phrase pattern
+        Do not return overly broad patterns such as "in + noun", "with + noun", or "to + verb" unless that broad pattern is the main learning point.
+        The pattern should be specific enough to make a new sentence.
+      - review_tag: short lowercase English tag for review, such as preposition, tense, article, word_order, collocation, infinitive, gerund, expression, translation
 
     Grammar explanations should be practical:
     Explain the reusable grammar rule behind each mistake or show common and frequently used collocation patterns not only the correction.
@@ -117,61 +126,18 @@ class JournalsController < ApplicationController
     ✗ Bad: 「文法的に誤りがあります」
 
     ====================
-    ENGLISH FEEDBACK RULES
+    learning_points RULES
     ====================
-    Analyze ONLY English usage. Do NOT comment on emotions or story content.
 
-    Focus on:
-    - Grammar tendencies
-    - Common mistake patterns
-    - Vocabulary usage
-    - Sentence structure
-    - naturalness of English
+      For learning_points.pattern:
+      - If mistake_type is grammar, return a reusable grammar pattern.
+        Example: "go to + place"
+      - If mistake_type is word_choice, return the natural word usage or collocation.
+        Example: "insecurity / insecurities about + noun"
+      - If mistake_type is expression, return the natural phrase pattern.
+        Example: "feel self-conscious about + noun"
+      - Do not choose a broad grammar pattern if the main issue is word choice.
 
-    Be specific to THIS text. Avoid generic comments.
-    ✓ Good: 「前置詞が抜けやすいです」「動名詞：'come to + 名詞 / 動名詞' の場合、'to' の後には動詞の原形ではなく、動名詞を使います。」
-    ✗ Bad: 「気持ちがよく伝わります」
-
-     Analyze the user's ENGLISH usage only.
-      Do NOT comment on emotions, story content, personality, or life situation.
-      Focus only on English writing.
-
-      Return:
-      - mistake_patterns = repeated English mistakes or weak areas
-      - native_phrases:
-        - provide 2 to 4 practical expressions native speakers naturally use to express the same feeling or situation in this journal.Do not return generic motivational phrases.
-        - Return at least 2 native_phrases, and give basic grammar rule.
-        - Each phrase must be useful in a different situation or nuance.
-        - Do not return duplicate or very similar phrases.
-        Do not return generic comfort phrases such as:
-        take it easy
-        no worries
-        stay positive
-        you got this
-
-      - If there is not enough evidence, return an empty array.
-      - Do not make the feedback overly short.
-      - Each explanation should be concrete and specific to this text.
-      - Avoid generic comments.
-
-      Examples of good mistake_patterns:
-      - 前置詞が抜けやすいです
-      - 時制が混ざりやすいです
-      - 冠詞 a / the を忘れやすいです
-      - 日本語直訳の語順になりやすいです
-
-      Examples of native_phrases:
-      provide practical native expressions related to the exact situation and meaning described in the journal.
-    #{' '}
-      1. The meaning in Japanese
-      2. When native speakers use it (context / situation)
-      3. Short nuance explanation
-      4. natural example sentence
-
-      Teach phrases in a practical learning style.
-
-      Do NOT analyze personality or emotional content.
-      Use only this text as evidence.
 
     ====================
     INPUT
@@ -191,28 +157,15 @@ class JournalsController < ApplicationController
             "original_text": "string (required)",
             "corrected_text": "string (required)",
             "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
-            "explanation": "text in Japanese (required)"
-          }
-        ],
-      "english_feedback": {
-        "mistake_patterns": [
-          {#{' '}
-          "point": "この文で見られた英語の傾向や弱点を分かりやすく。",
-          "evidence": "元の文の具体例",
-          "explanation": "このミスがなぜ起きているか、どう直すべきかを日本語で1〜2文。前置詞であればどうすべきか、時制ならどうすべきかなど具体的に"
-          }
-         ],
-        "native_phrases": [
-            {
-              "phrase": "native phrase and basic grammar rule",
-              "meaning": "日本語の意味",
-              "corrected_text": "添削後の文",
-              "example": "よく使う例文",
-              "example2": "よく使う例文"
+            "explanation": "text in Japanese (required)",
+            "learning_points": {
+              "label": "短い日本語ラベル。例: 前置詞 to の抜け",
+              "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environmentという形",
+              "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
+              "review_tag": "復習用の短い英語タグ。例: preposition"
             }
-          ]
-        }
-       }
+          }
+        ]
       }
 
       If the input contains Japanese text, classify all rewriting choices as "translation" type.
@@ -265,7 +218,8 @@ class JournalsController < ApplicationController
             original_text: note["original_text"],
             corrected_text: note["corrected_text"],
             mistake_type: note["mistake_type"],
-            explanation: note["explanation"]
+            explanation: note["explanation"],
+            learning_points: note["learning_points"] || {}
           )
         end
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -113,7 +113,7 @@ class JournalsController < ApplicationController
       Avoid explanations that only describe sentence flow, tone, or readability.
     - learning_points:
       - label: short Japanese label for the learning point
-      - pattern: 
+      - pattern:#{' '}
         reusable English grammar pattern or phrase pattern
         Do not return overly broad patterns such as "in + noun", "with + noun", or "to + verb" unless that broad pattern is the main learning point.
         The pattern should be specific enough to make a new sentence.

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -3,7 +3,7 @@ class JournalsController < ApplicationController
   before_action :authenticate_user!
   def index
     # @journals =current_user.journals.order(created_at: :desc)
-    @journals =current_user.journals.includes(:journal_correction).order(created_at: :desc)
+    @journals =current_user.journals.includes(:journal_correction).order(posted_date: :desc, id: :desc)
   end
 
   def show
@@ -206,9 +206,7 @@ class JournalsController < ApplicationController
         correction = @journal.create_journal_correction!(
           user_id: current_user.id,
           original_text: body,
-          rewritten_text: result["rewritten_text"],
-          mistake_patterns: result.dig("english_feedback", "mistake_patterns"),
-          native_phrases: result.dig("english_feedback", "native_phrases")
+          rewritten_text: result["rewritten_text"]
         )
 
         (result["notes"] || []).each do |note|
@@ -241,16 +239,9 @@ class JournalsController < ApplicationController
         #       explanation: note["explanation"]
         #   )
         # end
-        # 追加
-        # @overall = @journal.mistakes.find_by(mistake_type: "overall")
-        # @mistakes = @journal.mistakes.where.not(mistake_type: "overall")
-        # @english_feedback = result["english_feedback"]
-
-
 
         redirect_to @journal, notice: "添削が完了しました！"
       else
-        # Rails.logger.debug "=== journal errors: #{@journal.errors.full_messages}"
         flash.now[:alert] = "ジャーナルの作成に失敗しました。"
         render :new, status: :unprocessable_entity
       end

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -32,9 +32,27 @@
                 <span class="font-semibold">
                   <%= mistake_type_label(mistake.mistake_type) %>
                 </span>
-                <p class="text-base bg-gray-100 px-3 py-2 text-gray-600 mb-1">  【添削前】: <%= mistake.original_text %></p>
-                <p class="text-base bg-sage-50 border-l-2 border-forest-200 px-3 py-2">【添削後】：<%= mistake.corrected_text %></p>
+                <p class="text-base bg-gray-100 px-3 py-2 text-gray-600 mb-1">  
+                【添削前】: <%= mistake.original_text %></p>
+                <p class="text-base bg-sage-50 border-l-2 border-forest-200 px-3 py-2">
+                【添削後】：<%= mistake.corrected_text %></p>
                 <p class="text-base">ポイント： <%= mistake.explanation %></p>
+                <% if mistake.learning_points.present? %>
+                  <div class="text-base bg-white border border-cream-300 rounded-xl px-3 py-2 mt-2">
+                    <% if mistake.learning_points["review_tag"].present? %>
+                      <p>【復習タグ】<%= mistake.learning_points["review_tag"] %>
+                    <% end %>
+                    <% if mistake.learning_points["label"].present? %>
+                      (<%= mistake.learning_points["label"] %>)
+                    <% end %></p>
+                      <% if mistake.learning_points["meaning"].present? %>
+                        <p>【意味・ニュアンス】<%= mistake.learning_points["meaning"] %></p>
+                      <% end %>
+                    <% if mistake.learning_points["pattern"].present? %>
+                      <p>【覚える型】<%= mistake.learning_points["pattern"] %></p>
+                    <% end %>
+                  </div>
+                <% end %>
               </li>
             <% end %>
           </ol>
@@ -80,9 +98,10 @@
             <% @journal_correction.native_phrases&.each do |phrase| %>
             <div class="bg-white rounded-2xl p-3 mb-2">
               <p>【意味】<%= phrase["meaning"] %></p>
-              <p>【ネイティブがよく使う表現】<%= phrase["phrase"] %></p>
-              <p>【今回の文】<%= phrase["corrected_text"] %></p>
-              <p>【例文】</p>
+              <p>【覚えたい表現】<%= phrase["phrase"] %></p>
+              <p>【使い方（文法）】<%= phrase["grammarpattern"] %>
+              <p>【今回の日記では】<%= phrase["corrected_text"] %></p>
+              <p>【ほかの場面では】</p>
               <p><%= phrase["example"] %></p>
               <p><%= phrase["example2"] %></p>
             </div>

--- a/db/migrate/20260501151332_add_learning_points_to_mistakes.rb
+++ b/db/migrate/20260501151332_add_learning_points_to_mistakes.rb
@@ -1,0 +1,5 @@
+class AddLearningPointsToMistakes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :mistakes, :learning_points, :jsonb, default: {}, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_28_115420) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_01_151332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_28_115420) do
     t.datetime "updated_at", null: false
     t.integer "mistake_type"
     t.bigint "journal_correction_id"
+    t.jsonb "learning_points", default: {}, null: false
     t.index ["journal_correction_id"], name: "index_mistakes_on_journal_correction_id"
     t.index ["journal_id"], name: "index_mistakes_on_journal_id"
     t.index ["user_id"], name: "index_mistakes_on_user_id"

--- a/test/controllers/journals_controller_test.rb
+++ b/test/controllers/journals_controller_test.rb
@@ -32,7 +32,19 @@ end
   # OpenAI APIをモック化（実際には呼ばない）
   mock_result = {
     "rewritten_text" => "This is a test.",
-    "notes" => []
+    "notes" => [
+      {
+        "original_text" => "I went school",
+        "corrected_text" => "I went to school",
+        "mistake_type" => "grammar",
+        "explanation" => "場所へ行く場合は go to + 場所を使います",
+        "learning_points" => {
+          "label" => "前置詞 to の抜け",
+          "pattern" => "go to + 場所",
+          "review_tag" => "preposition"
+        }
+      }
+    ]
   }
 
   # OpenAI::Clientのchatメソッドを差し替える
@@ -46,7 +58,7 @@ end
   mock_client.expect(:chat, mock_response, parameters: Hash)
 
  OpenAI::Client.stub(:new, mock_client) do
-    assert_difference("Journal.count") do
+    assert_difference([ "Journal.count", "Mistake.count" ]) do
       post journals_url, params: {
         journal: {
           body:        "Test body",
@@ -58,6 +70,14 @@ end
       }
     end
     assert_redirected_to journal_url(Journal.last)
+    assert_equal(
+      {
+        "label" => "前置詞 to の抜け",
+        "pattern" => "go to + 場所",
+        "review_tag" => "preposition"
+      },
+      Mistake.last.learning_points
+    )
   end
 end
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
mistakesテーブルにlearning_pointsカラムを追加し、間違った言い回しがあった場合「覚える型」を表示できるようにしました。
また、english_feedbackを削除し、
AI添削後の画面からも間違いパターン・ネイティブがよく使う表現を表示しないようにしまし た。

## 背景
english_feedbackの削除に関して、AIプロンプトが長くなり、AIから返ってくる「今回の学び」の内容が薄くなっていたためです。

## 変更内容
  - mistakesテーブルにlearning_points カラム(jsonb)を追加
  - learning_pointsには以下のデータを格納
    - 復習タグ
    - 学習ポイント
    - 意味・ニュアンス
    - 覚える型
  - ジャーナリング添削時の出力から `english_feedback` / `native_phrases` / `mistake_patterns` を削除
  - プロンプトを調整

## 確認方法
  - [ ] ジャーナル投稿後、添削結果が表示されること
  - [ ] 「今回の学び」に復習タグ・意味/ニュアンス・覚える型が表示されること
  - [ ] 既存の添削前/添削後/ポイント表示が崩れていないこと

## 関連Issue
closes #