### PR TITLE
fix 学び一覧画面の修正

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -11,13 +11,18 @@ class JournalCorrectionsController < ApplicationController
   end
 
   def show
-    @journal_correction = current_user
-                          .journal_corrections
-                          .includes(:mistakes, :journal)
-                          .find(params[:id])
+    @journal_correction = current_user.journal_corrections.includes(:mistakes, :journal).find(params[:id])
 
     current_journal_id = @journal_correction.journal_id
-    @previous_journal_correction = current_user.journal_corrections.where("journal_id < ?", current_journal_id).order(journal_id: :desc).first
-    @next_journal_correction = current_user.journal_corrections.where("journal_id > ?", current_journal_id).order(journal_id: :asc).first
+    @previous_journal_correction = current_user.journal_corrections
+                                  .joins(:journal)
+                                  .where("journals.posted_date < ? OR (journals.posted_date = ? AND journals.id < ?)",
+                                  @journal_correction.journal.posted_date, @journal_correction.journal.posted_date, @journal_correction.journal_id)
+                                  .order("journals.posted_date DESC, journals.id DESC").first
+    @next_journal_correction = current_user.journal_corrections
+                               .joins(:journal)
+                               .where("journals.posted_date > ? OR (journals.posted_date = ? AND journals.id > ?)",
+                               @journal_correction.journal.posted_date, @journal_correction.journal.posted_date, @journal_correction.journal_id)
+                               .order("journals.posted_date ASC, journal_corrections.journal_id ASC").first
   end
 end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -13,8 +13,12 @@ class JournalsController < ApplicationController
     # @mistakes = @journal.mistakes.where.not(mistake_type: "overall")
     @journal_correction = @journal.journal_correction
     @mistakes = @journal_correction&.mistakes || []
-    @previous_journal = current_user.journals.where("id < ?", @journal.id).order(id: :desc).first
-    @next_journal = current_user.journals.where("id > ?", @journal.id).order(id: :asc).first
+    @previous_journal = current_user.journals
+                        .where("posted_date < ? OR (posted_date = ? AND id > ?)", @journal.posted_date, @journal.posted_date, @journal.id)
+                        .order(posted_date: :desc, id: :desc).first
+    @next_journal = current_user.journals
+                    .where("posted_date > ? OR (posted_date = ? AND id > ?)", @journal.posted_date, @journal.posted_date, @journal.id)
+                    .order(posted_date: :asc, id: :asc).first
   end
 
   def new

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -8,21 +8,28 @@
     <% if @journal_corrections.any? %>
       <div class="space-y-2">
       <%# journal_correctionsをループ %>
-      <% @journal_corrections.each do |journal_correction| %>
-
         <%# 1件ずつ枠で囲む %>
-        <%= link_to journal_correction_path(journal_correction),
+        <% @journal_corrections.each do |journal_correction| %>
+          <%= link_to journal_correction_path(journal_correction),
             class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
-        <p class="font-bold text-cream-500 mb-3">
-        <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>
-        </p>
+          <%# 日付 %>
+          <div class="font-bold text-cream-500 flex items-center gap-2">
+          <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
+            <div class="badge badge-soft badge-success badge-md text-white">
+            <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
+            </div>
+        </div>
+      
 
-        <p class="mb-3 line-clamp-2">
-          <%= journal_correction.rewritten_text %>
+        <div class="mb-2">
+          <% journal_correction.mistakes.first(2).each do |mistake| %>
+          <p><%= mistake.learning_points["pattern"] %>  </p>
+          <p class="text-gray-500">【意味】<%= mistake.learning_points["meaning"] %></p>
+            <% end %>
+        </div>
 
-        </p>
+          <% end %>
         <% end %>
-      <% end %>
       </div>
     <% else %>
       <div role="alert" class="alert alert-info alert-soft">

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -65,7 +65,7 @@
     <% end %>
 
     <%# 外側のカード %>
-    <% if @journal_correction&.present? %>
+    <% if @journal_correction&.mistake_patterns.present? || @journal_correction&.native_phrases.present? %>
       <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-2">
         <h3 class="font-semibold text-base mb-2">英語表現のポイント</h3>   
 
@@ -73,7 +73,7 @@
         <!--<div class="border border-gray-100 bg-white rounded-2xl p-4 mb-2"> -->
           <div class="mb-2">
 
-         <% if @journal_correction&.mistake_patterns.present? %>
+          <% if @journal_correction&.mistake_patterns.present? %>
           
           <div class="mb-2">
           <p class="badge badge-error p-3 mb-2">間違いパターン</p>
@@ -87,7 +87,7 @@
             <% end %>
           </div>
           <% end %>
-          <!--</div> -->
+          </div>
           
           <% if @journal_correction&.native_phrases.present? %>
           <hr class="border-forest-300 mb-2">
@@ -108,8 +108,9 @@
             <% end %>
           </div>
           <% end %>
+      <!--</div> -->
       </div>
     <% end %>
-  </div>
+
  <!-- </div>
 </div> -->


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
学び一覧画面を「添削後の英文」の表示から「learning_points」の表示に変更しました。

## 背景
「ジャーナリング一覧画面」と、「学び一覧画面」が類似しており差別化が必要だったため。

## 変更内容
  - 学び一覧に「〇つの学び」の件数表示を追加
  - 各 journal_correction に紐づく mistake の learning_points から、pattern と meaning を表示

## 確認方法
  - 学び一覧画面で learning_points が表示されること
  - learning_points の件数が表示されること

## 関連Issue
closes #