### PR TITLE
feat:学び詳細画面作成

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -12,6 +12,7 @@ class JournalCorrectionsController < ApplicationController
 
   def show
     @journal_correction = current_user.journal_corrections.includes(:mistakes, :journal).find(params[:id])
+    @journal = @journal_correction.journal
 
     current_journal_id = @journal_correction.journal_id
     @previous_journal_correction = current_user.journal_corrections

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -40,9 +40,9 @@ class JournalsController < ApplicationController
 
     raise "tone is nil!" if tone.blank?
 
-    # 2 AIへの指示(プロンプト)を作成する
+# 2 AIへの指示(プロンプト)を作成する
 
-    prompt = <<~PROMPT
+prompt = <<~PROMPT
     You are a bilingual Japanese-English writing teacher and correction coach who helps learners write natural American English and understand grammar clearly in Japanese.
     Your job is to REWRITE the user's message into natural, emotionally authentic American English without changing the original meaning.
     After each grammar correction, teach grammar formula / pattern and a tip.
@@ -90,6 +90,7 @@ class JournalsController < ApplicationController
     ====================
     Important:
     - Preserve the original meaning, emotional nuance, and timeline.
+    - corrected_text must be natural American English first.
     - Do NOT translate literally or preserve awkward wording
     - Do not over-specify what is only implied.
     - If the original text is vague, keep it naturally vague.
@@ -101,8 +102,9 @@ class JournalsController < ApplicationController
     ====================
     CORRECTION RULES
     ====================
-    - Return 5 to 7 notes for short input.
-    - Return 6 to 10 notes for longer input when there are enough useful learning points.
+    - Return 3 to 5 notes for short input.
+    - Return 5 to 7 notes for longer input when there are enough useful learning points.
+
     Do not only return the most serious mistakes.
     Include useful learning points from grammar, word choice, spelling, sentence structure, and natural expression.
     Each note should cover one specific learning point.
@@ -129,19 +131,62 @@ class JournalsController < ApplicationController
     ✓ Good: 「基本ルール：when it comes to + 名詞 / 動名詞」この表現の to は不定詞ではなく前置詞です。そのため後ろに動詞の原形 write は置けず、動名詞 writing を使います。
     ✗ Bad: 「文法的に誤りがあります」
 
+    Classification rules:
+    - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation
+
     ====================
     learning_points RULES
     ====================
-
       For learning_points.pattern:
-      - If mistake_type is grammar, return a reusable grammar pattern.
-        Example: "go to + place"
-      - If mistake_type is word_choice, return the natural word usage or collocation.
-        Example: "insecurity / insecurities about + noun"
-      - If mistake_type is expression, return the natural phrase pattern.
-        Example: "feel self-conscious about + noun"
-      - Do not choose a broad grammar pattern if the main issue is word choice.
+      Learning point selection priority:
+      1. Choose the most useful reusable phrase, collocation, or grammar pattern from corrected_text.
+      2. Prefer expressions learners can reuse in daily journaling.
+      3. Do not choose a basic grammar rule if corrected_text contains a more useful natural expression.
+      4. The pattern must be based on corrected_text, but do not make corrected_text unnatural just to match the pattern.
+      5. The pattern should be the smallest reusable unit that preserves the main meaning.
 
+      Related phrases:
+      - Return related_phrases only for the 2 most useful learning_points.
+      - For other notes, return related_phrases: [].
+      - related_phrases must be semantic alternatives to learning_points.pattern, not examples of the same pattern.
+      - phrase must be a reusable phrase pattern, not a full sentence.
+      - example must be a complete sentence using that phrase.
+    #{'  '}
+
+      Classification rules:
+      - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation.
+      - Use detailed categories such as tense, preposition, article, word_order, collocation, infinitive, gerund only in
+      learning_points.review_tag.
+
+        Only create a note when it teaches a useful reusable point for the learner.
+
+      ====================
+      LEARNING POINT SELECTION
+      ====================
+
+      Only create a note when it teaches a useful reusable point for the learner.
+
+      Priority:
+      1. Naturalness first: corrected_text must sound natural, emotionally authentic, and not overly formal.
+      2. Prefer useful collocations and natural expressions over basic grammar frames.
+      3. Choose patterns the learner can reuse for emotions, self-reflection, relationships, habits, worries, personal growth, and nuanced feelings.
+      4. Do not create a note for a change that is only a tiny style preference.
+      5. Do not replace a natural casual expression with a more formal one unless the selected tone requires it.
+      6. learning_points.pattern must be based on a natural phrase in corrected_text.
+      7. The pattern should be the smallest reusable unit that preserves the main meaning, but not overly generic or beginner-level.
+      8. The grammar placeholder in phrase and pattern must match the example sentence, such as + 名詞, + 動名詞, + to + 動詞, or + 主語 + 動詞.
+
+      Bad learning points:
+      - "I have many + 名詞"
+      - "I don't usually + 動詞 + with others"
+      - "often + feel + 動詞"
+      - "remove unnecessary words"
+
+      Good learning points:
+      - "insecurities about + 名詞"
+      - "share my feelings with + 人"
+      - "It often feels like + 主語 + 動詞"
+      - "have mixed feelings about + 名詞"
 
     ====================
     INPUT
@@ -163,10 +208,22 @@ class JournalsController < ApplicationController
             "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
             "explanation": "text in Japanese (required)",
             "learning_points": {
-              "label": "短い日本語ラベル。例: 前置詞 to の抜け",
+              "label": "短い日本語ラベル。例: 前置詞 to の抜け 動詞の形 語彙選択など",
               "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environmentという形",
               "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
-              "review_tag": "復習用の短い英語タグ。例: preposition"
+              "review_tag": "復習用の短い英語タグ。例: preposition",
+              "related_phrases":[
+              {
+               "phrase": "似たようなネイティブが使う自然な表現",
+               "meaning": "その表現の意味やニュアンスを日本語で説明",
+               "example": "完全な英語例文。"
+              },
+              {
+               "phrase": "似たようなネイティブが使う自然な表現",
+               "meaning": "その表現の意味やニュアンスを日本語で説明",
+                "example": "完全な英語例文。"
+               }
+              ]
             }
           }
         ]

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -13,24 +13,31 @@
           <%= link_to journal_correction_path(journal_correction),
             class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           <%# 日付 %>
-          <div class="font-bold text-cream-500 flex items-center gap-2">
-          <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
-            <div class="badge badge-soft badge-success badge-md text-white">
-            <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
-            </div>
-        </div>
+            <div class="font-bold text-cream-500 flex items-center gap-2">
+              <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
+              <div class="badge badge-soft badge-success badge-md text-white">
+                <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
+              </div>
+           </div>
       
 
         <div class="mb-2">
           <% journal_correction.mistakes.first(2).each do |mistake| %>
-          <p><%= mistake.learning_points["pattern"] %>  </p>
-          <p class="text-gray-500">【意味】<%= mistake.learning_points["meaning"] %></p>
-            <% end %>
+            <p class="font-semibold"><%= mistake.learning_points["pattern"] %></p>
+            <p class="text-gray-500">【意味】<%= mistake.learning_points["meaning"] %></p>
+          
+            <!--<% if mistake.learning_points["related_phrases"].present? %>
+              <% mistake.learning_points["related_phrases"].each do |phrase| %> 
+                <p><%= phrase["phrase"] %></p>
+                <p class="text-gray-500">【意味】<%= phrase["meaning"] %></p>
+              <% end %>
+            <% end %>-->
+          <% end %>
         </div>
-
           <% end %>
         <% end %>
       </div>
+    
     <% else %>
       <div role="alert" class="alert alert-info alert-soft">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -6,20 +6,24 @@
       <%= t('.title') %>
     </h1>
     
-    <div class="flex justify-between mb-1">
-      <% if @previous_journal_correction.present? %>
-        <%= link_to "前の日記", @previous_journal_correction, class:"btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
+    
+    <div class="flex justify-between gap-2 mb-1">
+      <div class="font-semibold mb-2"> 
+        <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>
+      </div>
+      <div class="flex gap-2 mb-2"><% if @previous_journal_correction.present? %>
+        <%= link_to "← 前の学び", @previous_journal_correction, class:"btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
       <% end %>
 
       <% if @next_journal_correction.present? %>
-        <%= link_to "次の日記", @next_journal_correction, class:"btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
+        <%= link_to "次の学び →", @next_journal_correction, class:"btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
       <% end %>
-  
+      </div>
     </div>
-    <div class="font-semibold mb-2"> <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %></div>
-    <%= render "shared/mistakes_list", mistakes: @journal_correction.mistakes, show_original_text: false %>
-    <!--<div class="font-semibold mb-2"> <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %> </div>
-    <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
+
+    <%# render "shared/mistakes_list", mistakes: @journal_correction.mistakes, show_original_text: false %>
+
+   <!-- <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <div class="flex items-center gap-2">
         <h2 class="font-semibold mb-3">添削後の文章</h2>
         <span class="badge badge-soft badge-success text-white mb-3 p-3">
@@ -31,9 +35,9 @@
           <%= @journal_correction.rewritten_text %>
           </p>
         </div>
-    </div>
+    </div> -->
 
-    <% if @journal_correction.mistakes.present? %>
+    <!--<% if @journal_correction.mistakes.present? %>
       <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
         <h2 class="font-semibold mb-3">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
 
@@ -56,54 +60,62 @@
       <div class="alert alert-success mb-4">
         <span>🎉 間違いは見つかりませんでした！</span>
       </div>
-    <% end %>
-
-    <%# 外側のカード %>
-    <% if @journal_correction&.strengths.present? %>
-      <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-2">
-        <h3 class="font-semibold text-base mb-2">英文の傾向</h3> -->
-       
-
-        <%# 内側の白部分 %>
-          <!-- <div class="mb-2">
-          <p class="badge badge-success text-white p-3 mb-2">良い点</p>
-            
-            <% (@journal_correction.strengths || []).each do |strength| %>
-              <div class="bg-white rounded-2xl p-4 mb-2">
-                <p class="font-semibold"><%= strength["point"] %></p>
-                <p>【元の文章】<%= strength["evidence"] %></p>
-                <p>【良かった点】<%= strength["why_it_works"] %></p>
-              </div>
-            <% end %>
-            
-          </div>
-
-          <hr class="border-forest-300 mb-2">
-          
-          <div class="mb-2">
-          <p class="badge badge-error p-3 mb-2">間違いパターン</p>
-            
-            <% (@journal_correction.mistake_patterns || []).each do |pattern| %> 
-              <div class="bg-white rounded-2xl p-3 mb-2">
-                <p class="font-semibold"><%= pattern["point"] %></p>
-                <p>【元の文章】<%= pattern["evidence"] %></p>
-                <p>【説明】<%= pattern["explanation"] %></p>
-              </div>
-            <% end %>
-          </div>
-          
-          <hr class="border-forest-300 mb-2">
-
-          <div class="mb-2">
-            <p class="badge badge-warning p-3 mb-2">アドバイス</p>
-            <div class="bg-white rounded-2xl p-3 mb-2">
-              <%= @journal_correction["advice"] %>
-            </div>
-          </div>
-
-     
-      </div>
     <% end %> -->
 
+    <%# 外側のカード %>
+    <% if @journal_correction.journal.mistakes&.present? %>
+        <%# 内側の白部分 %>
+           <div class="mb-2">
+              <% @journal_correction.mistakes.each do |mistake| %>
+              <div class="border border-forest-500 bg-white rounded-2xl overflow-hidden mb-3">
+                
+                <%# 学んだ表現 %>
+                <div class="bg-forest-50 p-3 mb-1">
+                  <p class="text-lg font-semibold text-forest-700">
+                    <%= mistake.learning_points["pattern"] %>
+                  </p>
+                  <p class="text-forest-600">
+                    <%= mistake.learning_points["meaning"] %>
+                  </p>
+                </div>
+
+                <%# 添削前・添削後の文章 %>
+                <div class="mx-3 text-gray-500 mb-2">今回の添削</div>
+                  <div class="mx-3 bg-red-50 rounded-xl px-2 py-2 mb-2">
+                    <p class=" text-red-500">添削前：<%= mistake.original_text %></p>
+                </div>
+                <div class="mx-3 bg-forest-50 rounded-xl px-2 py-2">
+                  <p class=" text-forest-600 font-semibold">添削後：<%= mistake.corrected_text %></p> 
+                </div>
+                <hr class="border-forest-500 mb-2 mt-2">
+
+              <%# ほかの表現・言い回し %>
+              <p class="mx-3 text-gray-500 mb-2">似た表現・言い回し</p>
+
+              <% mistake.learning_points["related_phrases"].each do |phrase| %>
+                <div class="mx-3 bg-white border border-gray-300 rounded-2xl p-3 mb-2">
+                  <p class="text-lg font-semibold"><%= phrase["phrase"] %><p>
+                  <p><%= phrase["meaning"] %></p>
+                  <p class=" text-forest-500 font-semibold"><%= phrase["example"] %></p>
+                </div> 
+              <% end %>
+                <%= link_to "この日記を見る", 
+                    @journal_correction.journal,
+                    class:"mx-3 flex items-center justify-center btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white mb-2" %>                     
+                </div>
+            <% end %>  
+          </div>
+  
+    
+    <% end %> 
+    <div class="flex justify-end gap-2 mb-1">
+      <% if @previous_journal_correction.present? %>
+        <%= link_to "← 前の学び", @previous_journal_correction, class:"btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
+      <% end %>
+
+      <% if @next_journal_correction.present? %>
+        <%= link_to "次の学び →", @next_journal_correction, class:"btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
+      <% end %>
+  
+    </div>
   </div>
-</div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -2,8 +2,8 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-bold font-title text-lg md:text-4xl sm:text-2xl text-center font-cream-500 mb-6">
-    My Journal
+    <h1 class="font-bold font-sans text-lg md:text-4xl sm:text-2xl text-center font-cream-500 mb-6">
+    ジャーナル一覧
     </h1>
 
       <!-- <div class="actions mb-4">
@@ -14,22 +14,22 @@
         <% @journals.each do |journal| %>
           <%#　1件ずつ枠で囲む  %>
           <div class="text-right">
-          <%= button_to "削除",
-              journal_path(journal),
-              method: :delete,
-              form: {data: {turbo_confirm:"このジャーナルを削除しますか？"}},
-              class: "text-sm text-center hover:opacity-70"
-          %>
+            <%= button_to "削除",
+                journal_path(journal),
+                method: :delete,
+                form: {data: {turbo_confirm:"このジャーナルを削除しますか？"}},
+                class: "text-sm text-center hover:opacity-70"
+            %>
           </div>
 
           <%= link_to journal_path(journal), class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           
           <p class="font-bold text-cream-500 mb-3">
-          <%= journal.posted_date.strftime("%Y/%m/%d") %>
+            <%= journal.posted_date.strftime("%Y/%m/%d") %>
           </p>
 
           <p class="mb-3 line-clamp-2">
-              <%= journal.journal_correction&.rewritten_text || journal.body %>
+            <%= journal.journal_correction&.rewritten_text || journal.body %>
           </p>
           <% end %>
         <% end %>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -23,8 +23,10 @@
 
     <% if @journal_correction.mistakes.present? %>
       <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-        <h2 class="font-semibold mb-3">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
-
+        <div class="flex justify-between">
+          <h2 class="font-semibold mb-3">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
+           <%= link_to "学び詳細を見る", @journal_correction, class: "btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
+        </div>
         <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
           <ol class="list-decimal list-inside">
             <% @journal_correction.mistakes.each do |mistake| %>
@@ -32,11 +34,15 @@
                 <span class="font-semibold">
                   <%= mistake_type_label(mistake.mistake_type) %>
                 </span>
-                <p class="text-base bg-gray-100 px-3 py-2 text-gray-600 mb-1">  
+                <p class="text-base bg-red-50 px-3 py-2 text-red-500 mb-1 rounded-xl">  
                 【添削前】: <%= mistake.original_text %></p>
-                <p class="text-base bg-sage-50 border-l-2 border-forest-200 px-3 py-2">
+                <p class="text-base bg-sage-50 border-l-2 text-forest-600 font-semibold border-forest-200 rounded-xl px-3 py-2">
                 【添削後】：<%= mistake.corrected_text %></p>
-                <p class="text-base">ポイント： <%= mistake.explanation %></p>
+
+                <p class="text-base mt-2">ポイント</p>
+                  <div class=" bg-cream-100 rounded-xl px-3 py-2">
+                    <p> <%= mistake.explanation %></p>
+                  </div>
                 <% if mistake.learning_points.present? %>
                   <div class="text-base bg-white border border-cream-300 rounded-xl px-3 py-2 mt-2">
                     <% if mistake.learning_points["review_tag"].present? %>
@@ -51,6 +57,28 @@
                     <% if mistake.learning_points["pattern"].present? %>
                       <p>【覚える型】<%= mistake.learning_points["pattern"] %></p>
                     <% end %>
+
+                    <!--<% if mistake.learning_points["related_phrases"].present? %>
+                      <div class="mt-2">
+                        <p class="font-semibold">似た表現</p>
+                        <% mistake.learning_points["related_phrases"].each do |phrase| %>
+                          <div class="mt-2 bg-sage-50 border-l-2 border-forest-200 px-3 py-2">
+                            <% if phrase["meaning"].present? %>
+                              <p>【意味】<%= phrase["meaning"] %></p>
+                            <% end %>
+
+                            <% if phrase["phrase"].present? %>
+                              <p>【表現】<%= phrase["phrase"] %></p>
+                            <% end %>
+
+                            <% if phrase["example"].present? %>
+                              <p>【例文】<%= phrase["example"] %></p>
+                            <% end %>
+                          </div>
+                        <% end %>
+                      </div>
+                    <% end %> -->
+
                   </div>
                 <% end %>
               </li>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
学び詳細画面を作成しました。


## 変更内容
  - 学び詳細画面で、学んだ表現・意味・今回の添削内容・似た表現を確認できるようにしました
  - 学び詳細画面に前後の学びへ移動するボタンを追加しました
  - 学び詳細画面から元の日記詳細へ戻れるリンクを追加しました
  - 日記詳細画面の「今回の学び」から学び詳細画面へ遷移できるようにしました
  - 学び一覧画面で、学びの内容が見やすくなるように表示を調整しました
  - AI添削プロンプトを調整し、`learning_points` に似た表現 `related_phrases` を含めるようにしました

## 確認方法
  - [x] 学び一覧画面が表示されること
  - [x] 学び詳細画面が表示されること
  - [x] 「前の学び」「次の学び」ボタンで前後の詳細画面に移動できること
  - [x] 学び詳細画面の「この日記を見る」から日記詳細画面へ移動できること
  - [x] 日記詳細画面の「学び詳細を見る」から学び詳細画面へ移動できること

## 関連Issue
closes #