### PR TITLE
refactor: AI添削プロンプトをBuilderに切り出す

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -8,9 +8,6 @@ class JournalsController < ApplicationController
 
   def show
     @journal = current_user.journals.find(params[:id])
-    # @overall = @journal.mistakes.find_by(mistake_type: "overall")
-    # @mistake = @journal.mistakes.first
-    # @mistakes = @journal.mistakes.where.not(mistake_type: "overall")
     @journal_correction = @journal.journal_correction
     @mistakes = @journal_correction&.mistakes || []
     @previous_journal = current_user.journals
@@ -33,207 +30,14 @@ class JournalsController < ApplicationController
       return
     end
 
-    # Rails.logger.debug "=== journal_params: #{journal_params.inspect}"
-    # 1 フォームから本文の文字列を受け取る
-    body = params[:journal][:body]
-    tone = params[:journal][:tone]
+      # 1 フォームから本文の文字列を受け取る
+      body = params[:journal][:body]
+      tone = params[:journal][:tone]
 
-    raise "tone is nil!" if tone.blank?
+      raise "tone is nil!" if tone.blank?
 
-# 2 AIへの指示(プロンプト)を作成する
-
-prompt = <<~PROMPT
-    You are a bilingual Japanese-English writing teacher and correction coach who helps learners write natural American English and understand grammar clearly in Japanese.
-    Your job is to REWRITE the user's message into natural, emotionally authentic American English without changing the original meaning.
-    After each grammar correction, teach grammar formula / pattern and a tip.
-    If the mistake is related to tense, present perfect, prepositions, gerunds, infinitives, or word order:
-
-    Always explain:
-    1. Basic grammar rule
-    2. Why it applies here
-    3. Corrected example
-    4. Short learning tip
-    If the user uses unnatural phrasing, explain the more natural expression.
-
-    ====================
-    TASK
-    ====================
-    Rewrite the user's text into natural American English, then provide corrections and feedback.
-
-    Tone: #{tone}
-    - polite:#{'  '}
-    Calm, thoughtful, emotionally mature natural American English.
-    Kind, steady, and respectful.
-    Slightly polished, but still simple and human.
-    Use everyday vocabulary, not formal or fancy words.
-    Gentle emotional restraint.
-    Longer smooth sentences are okay.
-    Reserved emotional tone.
-
-    - standard:
-    Warm, natural everyday American English.
-    Honest, balanced, believable.
-    Like a real native American writing privately.
-    Default natural tone.
-
-    - casual:
-    Warm, relaxed, conversational natural American English.
-    More spontaneous and emotionally close.
-    Use simple wording and natural flow.
-    Simple wording should not oversimplify meaning.
-    More immediate and human.
-
-    The user may write in Japanese or English.
-
-    ====================
-    REWRITE RULES
-    ====================
-    Important:
-    - Preserve the original meaning, emotional nuance, and timeline.
-    - corrected_text must be natural American English first.
-    - Do NOT translate literally or preserve awkward wording
-    - Do not over-specify what is only implied.
-    - If the original text is vague, keep it naturally vague.
-    - Do not over-specify implied information
-    - Rewrite into natural American English a real person would use.
-    - Understand Japanese nuance deeply before rewriting into natural American English.
-    - If the text is in Japanese, follow the flow of the original Japanese writing and rewrite the intended meaning into natural American English.
-
-    ====================
-    CORRECTION RULES
-    ====================
-    - Return 3 to 5 notes for short input.
-    - Return 5 to 7 notes for longer input when there are enough useful learning points.
-
-    Do not only return the most serious mistakes.
-    Include useful learning points from grammar, word choice, spelling, sentence structure, and natural expression.
-    Each note should cover one specific learning point.
-    Do not combine multiple unrelated issues into one note
-    For each mistake, provide:
-    - original_text
-    - corrected_text
-    - mistake_type: grammar | spelling | word_choice | expression | translation
-    - explanation (in Japanese)
-      First explain what is grammatically missing or unnatural in the original text.
-      Then explain the reusable English pattern used in the correction.
-      Avoid explanations that only describe sentence flow, tone, or readability.
-    - learning_points:
-      - label: short Japanese label for the learning point
-      - pattern:#{' '}
-        reusable English grammar pattern or phrase pattern
-        Do not return overly broad patterns such as "in + noun", "with + noun", or "to + verb" unless that broad pattern is the main learning point.
-        The pattern should be specific enough to make a new sentence.
-      - review_tag: short lowercase English tag for review, such as preposition, tense, article, word_order, collocation, infinitive, gerund, expression, translation
-
-    Grammar explanations should be practical:
-    Explain the reusable grammar rule behind each mistake or show common and frequently used collocation patterns not only the correction.
-    ✓ Good: 「前置詞：『部屋へ行く』は go to + place を使います」具体例を出し、使う組み合わせを提示する。
-    ✓ Good: 「基本ルール：when it comes to + 名詞 / 動名詞」この表現の to は不定詞ではなく前置詞です。そのため後ろに動詞の原形 write は置けず、動名詞 writing を使います。
-    ✗ Bad: 「文法的に誤りがあります」
-
-    Classification rules:
-    - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation
-
-    ====================
-    learning_points RULES
-    ====================
-      For learning_points.pattern:
-      Learning point selection priority:
-      1. Choose the most useful reusable phrase, collocation, or grammar pattern from corrected_text.
-      2. Prefer expressions learners can reuse in daily journaling.
-      3. Do not choose a basic grammar rule if corrected_text contains a more useful natural expression.
-      4. The pattern must be based on corrected_text, but do not make corrected_text unnatural just to match the pattern.
-      5. The pattern should be the smallest reusable unit that preserves the main meaning.
-
-      Related phrases:
-      - Return related_phrases only for the 2 most useful learning_points.
-      - For other notes, return related_phrases: [].
-      - related_phrases must be semantic alternatives to learning_points.pattern, not examples of the same pattern.
-      - phrase must be a reusable phrase pattern, not a full sentence.
-      - example must be a complete sentence using that phrase.
-    #{'  '}
-
-      Classification rules:
-      - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation.
-      - Use detailed categories such as tense, preposition, article, word_order, collocation, infinitive, gerund only in
-      learning_points.review_tag.
-
-        Only create a note when it teaches a useful reusable point for the learner.
-
-      ====================
-      LEARNING POINT SELECTION
-      ====================
-
-      Only create a note when it teaches a useful reusable point for the learner.
-
-      Priority:
-      1. Naturalness first: corrected_text must sound natural, emotionally authentic, and not overly formal.
-      2. Prefer useful collocations and natural expressions over basic grammar frames.
-      3. Choose patterns the learner can reuse for emotions, self-reflection, relationships, habits, worries, personal growth, and nuanced feelings.
-      4. Do not create a note for a change that is only a tiny style preference.
-      5. Do not replace a natural casual expression with a more formal one unless the selected tone requires it.
-      6. learning_points.pattern must be based on a natural phrase in corrected_text.
-      7. The pattern should be the smallest reusable unit that preserves the main meaning, but not overly generic or beginner-level.
-      8. The grammar placeholder in phrase and pattern must match the example sentence, such as + 名詞, + 動名詞, + to + 動詞, or + 主語 + 動詞.
-
-      Bad learning points:
-      - "I have many + 名詞"
-      - "I don't usually + 動詞 + with others"
-      - "often + feel + 動詞"
-      - "remove unnecessary words"
-
-      Good learning points:
-      - "insecurities about + 名詞"
-      - "share my feelings with + 人"
-      - "It often feels like + 主語 + 動詞"
-      - "have mixed feelings about + 名詞"
-
-    ====================
-    INPUT
-    ====================
-      Input text:
-      "#{body}"
-
-    ====================
-    OUTPUT JSON ONLY
-    ====================
-      Do not omit any keys.
-      Return ONLY valid JSON matching this exact structure:
-      {
-        "rewritten_text": "text (required)",
-        "notes":[
-          {
-            "original_text": "string (required)",
-            "corrected_text": "string (required)",
-            "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
-            "explanation": "text in Japanese (required)",
-            "learning_points": {
-              "label": "短い日本語ラベル。例: 前置詞 to の抜け 動詞の形 語彙選択など",
-              "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environmentという形",
-              "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
-              "review_tag": "復習用の短い英語タグ。例: preposition",
-              "related_phrases":[
-              {
-               "phrase": "似たようなネイティブが使う自然な表現",
-               "meaning": "その表現の意味やニュアンスを日本語で説明",
-               "example": "完全な英語例文。"
-              },
-              {
-               "phrase": "似たようなネイティブが使う自然な表現",
-               "meaning": "その表現の意味やニュアンスを日本語で説明",
-                "example": "完全な英語例文。"
-               }
-              ]
-            }
-          }
-        ]
-      }
-
-      If the input contains Japanese text, classify all rewriting choices as "translation" type.
-      For each translation note, explain in Japanese why the specific English word or phrase was chosen to express the original Japanese nuance.
-      english_feedback must be based only on THIS text.Be practical, modest, and helpful.
-      If there are no notes, return "notes": []
-      PROMPT
+      # 2 AIへの指示(プロンプト)を作成する(journal_prompt_builder.rbに移動)
+      prompt = JournalPromptBuilder.new(body: body, tone: tone).build
 
       # 3 OpenAI APIクライアントを初期化する
       client = OpenAI::Client.new
@@ -244,7 +48,6 @@ prompt = <<~PROMPT
           model: "gpt-4o-mini",
           messages: [ { role: "user", content: prompt } ],
           response_format: { type: "json_object" },
-
           temperature: 1.0
         }
       )

--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -1,0 +1,245 @@
+class JournalPromptBuilder
+  def initialize(body:, tone:)
+    @body = body
+    @tone = tone
+  end
+
+  # 2 AIへの指示(プロンプト)を作成する
+  def build
+   <<~PROMPT
+    You are a bilingual Japanese-English writing teacher and correction coach who helps learners write natural American English and understand grammar clearly in Japanese.
+
+    TASK:
+    Rewrite the user's text into natural, emotionally authentic American English,
+    then provide concise learning notes in Japanese.
+
+    ====================
+    REWRITE (HIGHEST PRIORITY)
+    ====================
+    CRITICAL:
+    - Generate rewritten_text FIRST and independently.
+    - Do NOT translate sentence by sentence.
+    - First understand the meaning and emotional nuance.
+    - Then rewrite as if the speaker originally thought in English.
+
+    STYLE:
+    - Write like a native speaker’s personal journal / inner monologue.
+    - Naturalness > emotional authenticity > meaning > structure.
+    - Prefer simple, direct wording over polished or explanatory phrasing.
+    - Preserve emotional flow, not sentence structure.
+    - You may restructure, merge, reorder, or simplify sentences.
+    - Keep natural vagueness if the original is vague.
+    - Use everyday American English and natual expressions (not too formal, not textbook-like).
+    - Use natural rhythm (mix short and medium sentences).
+
+    PREFER:
+    - emotional reactions over explanations
+    - personal tone over general statements
+    - human-like flow and pacing
+    - match the original emotional tone and intensity closely; do not amplify it
+
+    CRITICAL:
+    - Do NOT over-interpret or expand the original meaning
+
+    STRONGLY AVOID:
+    - literal translation from Japanese
+    - unnatural phrasing (e.g., "overwrite emotions")
+    - overly formal or textbook-like writing
+    - rigidly preserving original sentence structure
+    - adding slang or trendy expressions (e.g., "no-no", "like, what?")
+    - making the writing more dramatic than the original
+
+
+    TONE:
+    #{tone}
+    #{tone_description}
+
+    ====================
+    CORRECTION RULES
+    ====================
+    - Return 3 to 5 notes for short input.
+    - Return 5 to 7 notes for longer input when there are enough useful learning points.
+
+    Do not only return the most serious mistakes.
+    Include useful learning points from grammar, word choice, spelling, sentence structure, and natural expression.
+    Each note should cover one specific learning point.
+    Do not combine multiple unrelated issues into one note
+    For each mistake, provide:
+    - original_text
+    - corrected_text
+    - mistake_type: grammar | spelling | word_choice | expression | translation
+    - explanation (in Japanese)
+      First explain what is grammatically missing or unnatural in the original text.
+      Then explain the reusable English pattern used in the correction.
+      Avoid explanations that only describe sentence flow, tone, or readability.
+    - learning_points:
+      - label: short Japanese label for the learning point
+      - pattern:#{' '}
+        reusable English grammar pattern or phrase pattern
+        Do not return overly broad patterns such as "in + noun", "with + noun", or "to + verb" unless that broad pattern is the main learning point.
+        The pattern should be specific enough to make a new sentence.
+      - review_tag: short lowercase English tag for review, such as preposition, tense, article, word_order, collocation, infinitive, gerund, expression, translation
+
+    Grammar explanations should be practical:
+    Explain the reusable grammar rule behind each mistake or show common and frequently used collocation patterns not only the correction.
+    ✓ Good: 「前置詞：『部屋へ行く』は go to + place を使います」具体例を出し、使う組み合わせを提示する。
+    ✓ Good: 「基本ルール：when it comes to + 名詞 / 動名詞」この表現の to は不定詞ではなく前置詞です。そのため後ろに動詞の原形 write は置けず、動名詞 writing を使います。
+    ✗ Bad: 「文法的に誤りがあります」
+
+    Classification rules:
+    - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation
+
+    ====================
+    learning_points RULES
+    ====================
+      For learning_points.pattern:
+      Learning point selection priority:
+      1. Choose the most useful reusable phrase, collocation, or grammar pattern from corrected_text.
+      2. Prefer expressions learners can reuse in daily journaling.
+      3. Do not choose a basic grammar rule if corrected_text contains a more useful natural expression.
+      4. The pattern must be based on corrected_text, but do not make corrected_text unnatural just to match the pattern.
+      5. The pattern should be the smallest reusable unit that preserves the main meaning.
+
+      Related phrases:
+      - Return related_phrases only for the 2 most useful learning_points.
+      - Reject patterns that only describe actions or situations.
+      - Reject patterns that are too basic or obvious for learners.
+      - Reject patterns that do not change the meaning of the sentence when removed.
+      - They MUST have the same core meaning and function
+      - They MUST be interchangeable in the same context
+      - For other notes, return related_phrases: [].
+      - related_phrases must be semantic alternatives to learning_points.pattern, not examples of the same pattern.
+      - phrase must be a reusable phrase pattern, not a full sentence.
+      - example must be a complete sentence using that phrase.
+    #{'  '}
+
+      Classification rules:
+      - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation.
+      - Use detailed categories such as tense, preposition, article, word_order, collocation, infinitive, gerund only in learning_points.review_tag.
+
+      Only create a note when it teaches a useful reusable point for the learner.
+
+      ====================
+      LEARNING POINT SELECTION
+      ====================
+      Only create a note when it teaches a HIGH-VALUE useful reusable point for the learner.
+
+      Priority:
+      1. Naturalness first: corrected_text must sound natural, emotionally authentic, and not overly formal.
+      2. Prefer useful collocations and natural expressions over basic grammar frames.
+      3. Choose patterns the learner can reuse for emotions, self-reflection, relationships, habits, worries, personal growth, and nuanced feelings.
+      4. Do not create a note for a change that is only a tiny style preference.
+      5. Do not replace a natural casual expression with a more formal one unless the selected tone requires it.
+      6. learning_points.pattern must be based on a natural phrase in corrected_text.
+      7. The pattern should be the smallest reusable unit that preserves the main meaning, but not overly generic or beginner-level.
+      8. The grammar placeholder in phrase and pattern must match the example sentence, such as + 名詞, + 動名詞, + to + 動詞, or + 主語 + 動詞.
+
+      DO NOT SELECT patterns like:
+        - be + adjective
+        - be so + adjective
+        - very + adjective
+        - basic subject + verb structures
+
+      BAD:
+        - be so + 形容詞
+        - I am + 形容詞
+        - very + 形容詞
+
+      Good learning points:
+      - "insecurities about + 名詞"
+      - "share my feelings with + 人"
+      - "It often feels like + 主語 + 動詞"
+      - have mixed feelings about + 名詞
+      - the way people think shapes + 名詞
+
+      ====================
+      INPUT
+      ====================
+      Input text:
+      "#{body}"
+
+      #{output_format}
+      PROMPT
+    end
+
+    private
+
+    attr_reader :body, :tone
+
+    def tone_description
+        case tone
+        when "polite"
+          <<~DESC
+            - polite:
+                Calm, thoughtful, emotionally mature natural American English.
+                Kind, steady, and respectful.
+                Slightly polished, but still simple and human.
+                Use everyday vocabulary, not formal or fancy words.
+                Gentle emotional restraint.
+                Longer smooth sentences are okay.
+                Reserved emotional tone.
+            DESC
+        when "standard"
+          <<~DESC
+            - standard:
+                Warm, natural everyday American English.
+                Honest, balanced, believable.
+                Like a real native American writing privately.
+                Default natural tone.
+             DESC
+        when "casual"
+          <<~DESC
+            - casual:
+                Warm, relaxed, conversational natural American English.
+                More spontaneous and emotionally close.
+                Use simple wording and natural flow.
+                Simple wording should not oversimplify meaning.
+                More immediate and human.
+             DESC
+        end
+    end
+
+    def output_format
+        <<~FORMAT
+            ====================
+            OUTPUT JSON ONLY
+            ====================
+            Do not omit any keys.
+            Return ONLY valid JSON matching this exact structure:
+            {
+                "rewritten_text": "text (required)",
+                "notes":[
+                {
+                    "original_text": "string (required)",
+                    "corrected_text": "string (required)",
+                    "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
+                    "explanation": "text in Japanese (required)",
+                    "learning_points": {
+                    "label": "短い日本語ラベル。例: 前置詞 to の抜け 動詞の形 語彙選択など",
+                    "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environmentという形",
+                    "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
+                    "review_tag": "復習用の短い英語タグ。例: preposition",
+                    "related_phrases":[
+                    {
+                    "phrase": "似たようなネイティブが使う自然な表現",
+                    "meaning": "その表現の意味やニュアンスを日本語で説明",
+                    "example": "完全な英語例文。"
+                    },
+                    {
+                    "phrase": "似たようなネイティブが使う自然な表現",
+                    "meaning": "その表現の意味やニュアンスを日本語で説明",
+                        "example": "完全な英語例文。"
+                    }
+                    ]
+                    }
+                }
+                ]
+            }
+
+            If the input contains Japanese text, classify all rewriting choices as "translation" type.
+            For each translation note, explain in Japanese why the specific English word or phrase was chosen to express the original Japanese nuance.
+            english_feedback must be based only on THIS text.Be practical, modest, and helpful.
+            If there are no notes, return "notes": []
+           FORMAT
+    end
+end

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -92,7 +92,7 @@
               <%# ほかの表現・言い回し %>
               <p class="mx-3 text-gray-500 mb-2">似た表現・言い回し</p>
 
-              <% mistake.learning_points["related_phrases"].each do |phrase| %>
+              <% Array(mistake.learning_points["related_phrases"]).compact.each do |phrase| %>
                 <div class="mx-3 bg-white border border-gray-300 rounded-2xl p-3 mb-2">
                   <p class="text-lg font-semibold"><%= phrase["phrase"] %><p>
                   <p><%= phrase["meaning"] %></p>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,12 +1,3 @@
-<!-- <%= content_for(:title, t('.title', default: APP_NAME)) %> 
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    
-    <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6">
-      <%= t('.title') %>
-    </h1>
-
-    <div class="font-semibold mb-2"> <%# @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %> </div>-->
     <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <div class="flex items-center gap-2">
         <h2 class="font-semibold mb-3">添削後の文章</h2>
@@ -23,9 +14,9 @@
 
     <% if @journal_correction.mistakes.present? %>
       <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-        <div class="flex justify-between">
-          <h2 class="font-semibold mb-3">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
-           <%= link_to "学び詳細を見る", @journal_correction, class: "btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
+        <div class="flex justify-between mb-3">
+          <h2 class="font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
+           <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
         </div>
         <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
           <ol class="list-decimal list-inside">
@@ -45,12 +36,12 @@
                   </div>
                 <% if mistake.learning_points.present? %>
                   <div class="text-base bg-white border border-cream-300 rounded-xl px-3 py-2 mt-2">
-                    <% if mistake.learning_points["review_tag"].present? %>
+                    <!--<% if mistake.learning_points["review_tag"].present? %>
                       <p>【復習タグ】<%= mistake.learning_points["review_tag"] %>
-                    <% end %>
+                    <% end %> 
                     <% if mistake.learning_points["label"].present? %>
                       (<%= mistake.learning_points["label"] %>)
-                    <% end %></p>
+                    <% end %></p>-->
                       <% if mistake.learning_points["meaning"].present? %>
                         <p>【意味・ニュアンス】<%= mistake.learning_points["meaning"] %></p>
                       <% end %>
@@ -141,4 +132,3 @@
     <% end %>
 
  <!-- </div>
-</div> -->

--- a/test/controllers/journal_corrections_controller_test.rb
+++ b/test/controllers/journal_corrections_controller_test.rb
@@ -24,4 +24,21 @@ class JournalCorrectionsControllerTest < ActionDispatch::IntegrationTest
     get journal_correction_url(@journal_correction)
     assert_response :success
   end
+
+  test "should get show when related phrases are not saved" do
+    @journal_correction.mistakes.create!(
+      journal: @journal,
+      user: @user,
+      original_text: "I went school",
+      corrected_text: "I went to school",
+      explanation: "場所へ行く場合は go to + 場所を使います",
+      learning_points: {
+        "pattern" => "go to + 場所",
+        "meaning" => "場所へ行くという意味です"
+      }
+    )
+
+    get journal_correction_url(@journal_correction)
+    assert_response :success
+  end
 end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
Journal作成時に使用しているAI添削プロンプトを `JournalPromptBuilder` に切り出しました。

## 変更内容
  - `JournalPromptBuilder` を追加し、AI添削プロンプトの組み立て処理をControllerから分離
  - `JournalsController#create` から長いプロンプト文字列を削除し、Builderを呼び出す形に変更

## 確認方法
  - [x] 日記作成時にAI添削が実行されること
  - [x] 日記作成後、日記詳細画面へ遷移できること
  - [x] 日記詳細画面の「表現を復習する」から学び詳細画面へ遷移できること


## 関連Issue
closes #120
closes #121 