### PR TITLE
feat:ホーム画面に学習サマリーを追加

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,11 @@ class HomeController < ApplicationController
 
   def index
     # @journals = current_user.journals.order(posted_date: :desc).limit(3)
-    @journals = current_user.journals.includes(:mistakes, :journal_correction).order(posted_date: :desc).limit(3)
-    @monthly_count = current_user.journals.where(posted_date: Date.current.beginning_of_month..Date.current.end_of_month).count
+    @journals = current_user.journals.includes(:mistakes, :journal_correction).order(posted_date: :desc, id: :desc).limit(3)
+    @total_count = current_user.total_journal_count
+    @monthly_count = current_user.this_month_journal_count
+    @total_learning_count = current_user.total_learning_count
+    @monthly_learning_count = current_user.this_month_learning_count
+    @streak_count = current_user.streak_dates
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,42 @@ class User < ApplicationRecord
          :recoverable,
          :rememberable,
          :validatable
+
+  def total_journal_count
+    journals.distinct.count
+  end
+
+  def this_month_journal_count
+    journals.where(posted_date: Date.current.all_month).distinct.count
+  end
+
+  def total_learning_count
+    mistakes.joins(:journal)
+            .where("learning_points ->> 'pattern' IS NOT NULL")
+            .where.not("learning_points ->> 'pattern' = ''")
+            .distinct
+            .count
+  end
+
+  def this_month_learning_count
+    mistakes.joins(:journal)
+            .where(journals: { posted_date: Date.current.all_month })
+            .where("learning_points ->> 'pattern' IS NOT NULL")
+            .where.not("learning_points ->> 'pattern' = ''")
+            .distinct
+            .count
+  end
+
+  def streak_dates
+    posted_dates = journals.distinct.pluck(:posted_date)
+
+    count = 0
+    date = posted_dates.include?(Date.current) ? Date.current : Date.yesterday
+
+    while posted_dates.include?(date)
+      count += 1
+      date -= 1.day
+    end
+    count
+  end
 end

--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -133,6 +133,7 @@ class JournalPromptBuilder
       6. learning_points.pattern must be based on a natural phrase in corrected_text.
       7. The pattern should be the smallest reusable unit that preserves the main meaning, but not overly generic or beginner-level.
       8. The grammar placeholder in phrase and pattern must match the example sentence, such as + 名詞, + 動名詞, + to + 動詞, or + 主語 + 動詞.
+      9. Prefer patterns that capture the core meaning or emotional intent of the sentence, not just its structure.
 
       DO NOT SELECT patterns like:
         - be + adjective

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -5,15 +5,32 @@
     <h1 class="font-title font-bold text-2xl sm:text-3xl md:text-4xl mb-6 leading-tight">
     <%= current_user.name %>'s Journal
     </h1>
-  
-    <div class="border border-cream-300 bg-white rounded-2xl p-5 mb-4">
-      
-        <p class="font-bold font-sans text-base sm:text-lg md:text-xl mb-4">
-          今日の気持ちを英語にしてみよう
-        </p>
-        
-        <div class="flex justify-center">
-        <%= link_to "書いてみる", new_journal_path, class:"btn btn-primary w-64 mb-2" %>
+
+    <div class="flex justify-center gap-2 mb-4">
+      <div class="bg-forest-50 rounded-2xl p-3 text-center flex-1">
+        <p class="text-2xl font-semibold text-forest-500"><%= @total_count %></p>
+        <p class="text-sm text-ink-muted">総投稿数</p>
+      </div>
+      <div class="bg-forest-50 rounded-2xl p-3 text-center flex-1">
+        <p class="text-2xl font-semibold text-forest-500"><%= @total_learning_count %></p>
+        <p class="text-sm text-ink-muted">累計学び数</p>
+      </div>
+      <div class="bg-forest-50 rounded-2xl p-3 text-center flex-1">
+        <p class="text-2xl font-semibold text-forest-500"><%= @streak_count %>日</p>
+        <p class="text-sm text-ink-muted">連続投稿日数</p>
+      </div>
+    </div>
+
+    <div class="bg-forest-50 rounded-2xl p-5 mb-4">
+      <%# 今日の気持ちを英語にしてみよう %>
+      <p class="font-bold font-sans text-base text-center text-forest-500 sm:text-lg md:text-xl mb-1">
+        今日、心が動いたことは？
+      </p>
+      <p class="text-center sm:text-base text-forest-600 mb-2">
+        日本語でも英語でも、気持ちを書き残してみよう
+      </p>
+      <div class="flex justify-center">
+        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64" %>
       </div>
     </div>
     <!-- <div class="flex gap-3 mb-4">
@@ -48,7 +65,7 @@
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           
-            <%= link_to journal_path(journal), class: "btn btn-sm btn-outline" do %>
+            <%= link_to journal_path(journal), class: "btn btn-sm bg-forest-500 text-white hover:bg-forest-500 hover:opacity-80" do %>
             View Details
             <% end %>
             </div>

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -71,7 +71,7 @@
                 
                 <%# 学んだ表現 %>
                 <div class="bg-forest-50 p-3 mb-1">
-                  <p class="text-lg font-semibold text-forest-700">
+                  <p class="text-lg font-bold text-forest-700">
                     <%= mistake.learning_points["pattern"] %>
                   </p>
                   <p class="text-forest-600">
@@ -94,7 +94,7 @@
 
               <% Array(mistake.learning_points["related_phrases"]).compact.each do |phrase| %>
                 <div class="mx-3 bg-white border border-gray-300 rounded-2xl p-3 mb-2">
-                  <p class="text-lg font-semibold"><%= phrase["phrase"] %><p>
+                  <p class="text-lg font-bold"><%= phrase["phrase"] %></p>
                   <p><%= phrase["meaning"] %></p>
                   <p class=" text-forest-500 font-semibold"><%= phrase["example"] %></p>
                 </div> 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ホーム画面にユーザーの学習サマリー（総投稿数・累計学び数・連続投稿日数）を追加しました。

## 変更内容
  - ホーム画面に以下のサマリー表示を追加
    - 総投稿数
    - 累計学び数
    - 連続投稿日数
  - `User` モデルに投稿数・学び数・連続投稿日数を集計するメソッドを追加

## 確認方法

  - [x] ホーム画面に総投稿数・累計学び数・連続投稿日数が表示される
  - [x] 投稿がない場合でもホーム画面が表示される
  - [x] 今日または昨日から連続投稿数がカウントされる

## 関連Issue
closes #132
closes #133 