### PR TITLE
fix:UIの調整・learning_pointsのプロンプト調整

### DIFF
--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -6,7 +6,7 @@ class JournalPromptBuilder
 
   # 2 AIへの指示(プロンプト)を作成する
   def build
-   <<~PROMPT
+    <<~PROMPT
     You are a bilingual Japanese-English writing teacher and correction coach who helps learners write natural American English and understand grammar clearly in Japanese.
 
     TASK:
@@ -24,7 +24,7 @@ class JournalPromptBuilder
 
     STYLE:
     - Write like a native speaker’s personal journal / inner monologue.
-    - Naturalness > emotional authenticity > meaning > structure.
+    - Meaning and emotional nuance > naturalness > tone > structure.
     - Prefer simple, direct wording over polished or explanatory phrasing.
     - Preserve emotional flow, not sentence structure.
     - You may restructure, merge, reorder, or simplify sentences.
@@ -70,7 +70,7 @@ class JournalPromptBuilder
     - mistake_type: grammar | spelling | word_choice | expression | translation
     - explanation (in Japanese)
       First explain what is grammatically missing or unnatural in the original text.
-      Then explain the reusable English pattern used in the correction.
+      Then identify the most reusable and natural English expression from the corrected_text that learners could realistically use again in their own emotional writing or conversation.
       Avoid explanations that only describe sentence flow, tone, or readability.
     - learning_points:
       - label: short Japanese label for the learning point
@@ -81,7 +81,7 @@ class JournalPromptBuilder
       - review_tag: short lowercase English tag for review, such as preposition, tense, article, word_order, collocation, infinitive, gerund, expression, translation
 
     Grammar explanations should be practical:
-    Explain the reusable grammar rule behind each mistake or show common and frequently used collocation patterns not only the correction.
+    Explain or show common and frequently used collocation patterns not only the correction.
     ✓ Good: 「前置詞：『部屋へ行く』は go to + place を使います」具体例を出し、使う組み合わせを提示する。
     ✓ Good: 「基本ルール：when it comes to + 名詞 / 動名詞」この表現の to は不定詞ではなく前置詞です。そのため後ろに動詞の原形 write は置けず、動名詞 writing を使います。
     ✗ Bad: 「文法的に誤りがあります」
@@ -92,155 +92,189 @@ class JournalPromptBuilder
     ====================
     learning_points RULES
     ====================
-      For learning_points.pattern:
-      Learning point selection priority:
-      1. Choose the most useful reusable phrase, collocation, or grammar pattern from corrected_text.
-      2. Prefer expressions learners can reuse in daily journaling.
-      3. Do not choose a basic grammar rule if corrected_text contains a more useful natural expression.
-      4. The pattern must be based on corrected_text, but do not make corrected_text unnatural just to match the pattern.
-      5. The pattern should be the smallest reusable unit that preserves the main meaning.
+    IMPORTANT:
+    The corrected sentence may be natural and flexible, but the learning point must be a reusable natural English expression, not a description of how the sentence was translated.
 
-      Related phrases:
-      - Return related_phrases only for the 2 most useful learning_points.
-      - Reject patterns that only describe actions or situations.
-      - Reject patterns that are too basic or obvious for learners.
-      - Reject patterns that do not change the meaning of the sentence when removed.
-      - They MUST have the same core meaning and function
-      - They MUST be interchangeable in the same context
-      - For other notes, return related_phrases: [].
-      - related_phrases must be semantic alternatives to learning_points.pattern, not examples of the same pattern.
-      - phrase must be a reusable phrase pattern, not a full sentence.
-      - example must be a complete sentence using that phrase.
-    #{'  '}
+    CRITICAL RULE:
+    If the learner cannot realistically create a full sentence using only the pattern, DO NOT select it.
+    Choose expressions that native speakers would naturally remember and reuse as one unit.
+    Use placeholders ONLY when native speakers naturally think of the expression as a reusable pattern.
+    If corrected_text contains a high-value idiomatic expression, choose it over a literal translation.
+    #{' '}
+    For learning_points.pattern:
+    Learning point selection priority:
+    1. Choose the most useful reusable phrase, collocation, or grammar pattern from corrected_text.
+    2. Prefer expressions learners can reuse in daily journaling.
+    3. Do not choose a basic grammar rule if corrected_text contains a more useful natural expression.
+    4. The pattern must be based on corrected_text, but do not make corrected_text unnatural just to match the pattern.
+    5. A pattern must teach a useful expression, not just an intensifier like "so", "very", "really", or "too".
 
-      Classification rules:
-      - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation.
-      - Use detailed categories such as tense, preposition, article, word_order, collocation, infinitive, gerund only in learning_points.review_tag.
+    For learning_points.pattern:
+    - Do NOT copy the full corrected sentence as the pattern.
+    - The pattern must be a reusable phrase or structure, not a one-time translation.
+    - If the corrected_text is a full sentence, extract only the most reusable part.
+    - Use placeholders only when they make the expression naturally reusable.
+    - Reject patterns that are only a literal translation of the original Japanese.
+    - Reject fragments that are unnatural when reused by themselves.
+    - If there is no reusable learning point, do not create a note.
 
-      Only create a note when it teaches a useful reusable point for the learner.
+    Related phrases:
+    - Return related_phrases only for the 2 most useful learning_points.
+    - Reject patterns that only describe actions or situations.
+    - Reject patterns that are too basic or obvious for learners.
+    - Reject patterns that do not change the meaning of the sentence when removed.
+    - They MUST have the same core meaning and function.
+    - They MUST be interchangeable in the same context.
+    - The pattern should prioritize natural English usage and reusable emotional expression, not abstract grammar formulas.
+    - Do NOT include vague descriptions such as "something happening" or "a situation".
+    - For other notes, return related_phrases: [].
+    - related_phrases must be semantic alternatives to learning_points.pattern, not examples of the same pattern.
+    - phrase must be a reusable phrase pattern, not a full sentence.
+    - example must be a complete sentence using that phrase.
 
-      ====================
-      LEARNING POINT SELECTION
-      ====================
-      Only create a note when it teaches a HIGH-VALUE useful reusable point for the learner.
+    Classification rules:
+    - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation.
+    - Use detailed categories such as tense, preposition, article, word_order, collocation, infinitive, gerund only in learning_points.review_tag.
 
-      Priority:
-      1. Naturalness first: corrected_text must sound natural, emotionally authentic, and not overly formal.
-      2. Prefer useful collocations and natural expressions over basic grammar frames.
-      3. Choose patterns the learner can reuse for emotions, self-reflection, relationships, habits, worries, personal growth, and nuanced feelings.
-      4. Do not create a note for a change that is only a tiny style preference.
-      5. Do not replace a natural casual expression with a more formal one unless the selected tone requires it.
-      6. learning_points.pattern must be based on a natural phrase in corrected_text.
-      7. The pattern should be the smallest reusable unit that preserves the main meaning, but not overly generic or beginner-level.
-      8. The grammar placeholder in phrase and pattern must match the example sentence, such as + 名詞, + 動名詞, + to + 動詞, or + 主語 + 動詞.
-      9. Prefer patterns that capture the core meaning or emotional intent of the sentence, not just its structure.
+    Only create a note when it teaches a useful reusable point for the learner.
 
-      DO NOT SELECT patterns like:
-        - be + adjective
-        - be so + adjective
-        - very + adjective
-        - basic subject + verb structures
+    ====================
+    LEARNING POINT SELECTION
+    ====================
+    Only create a note when it teaches a HIGH-VALUE useful reusable point for the learner.
 
-      BAD:
-        - be so + 形容詞
-        - I am + 形容詞
-        - very + 形容詞
+    Priority:
+    1. Naturalness first: corrected_text must sound natural, emotionally authentic, and not overly formal.
+    2. Prefer useful collocations and natural expressions over basic grammar frames.
+    3. Choose patterns the learner can reuse for emotions, self-reflection, relationships, habits, worries, personal growth, and nuanced feelings.
+    4. The pattern should preferably be a reusable native-like phrase, collocation, or emotional expression.
+    5. Do not create a note for a change that is only a tiny style preference.
+    6. Do not replace a natural casual expression with a more formal one unless the selected tone requires it.
+    7. learning_points.pattern must be based on a natural phrase in corrected_text.
+    8. The pattern should be large enough to preserve the natural emotional meaning and native usage. Do not reduce expressions into generic grammar skeletons.
+    9. Prefer patterns that capture the core meaning or emotional intent of the sentence, not just its structure. Grammar structures should only be selected when native speakers naturally think of them as reusable patterns.
 
-      Good learning points:
-      - "insecurities about + 名詞"
-      - "share my feelings with + 人"
-      - "It often feels like + 主語 + 動詞"
-      - have mixed feelings about + 名詞
-      - the way people think shapes + 名詞
+    Use only these Japanese placeholders in learning_points.pattern:
+    - + 名詞
+    - + 動詞
+    - + 動名詞
+    - + 名詞 / 動名詞
+    - + 人
+    - + 文(主語 + 動詞)#{' '}
+    - + 主語 + 動詞
+    - + 疑問文
 
-      ====================
-      INPUT
-      ====================
-      Input text:
-      "#{body}"
+    BAD:
+    - be so + 形容詞
+    - really + 形容詞
+    - feelings are + adjective
+    - be + adjective + for + 人
+    - I wonder + clause
+    - wonder how to + 動詞
+    - Why do I + 動詞 + 目的語？
+    - I feel + adjective + about + noun
+    - I’m + adjective + but + sentence
+    - why can't they just + verb
 
-      #{output_format}
-      PROMPT
+    Good learning points:
+    - "insecurities about + 名詞"
+    - "share my feelings with + 人"
+    - "It often feels like + 主語 + 動詞"
+    - "have mixed feelings about + 名詞"
+    - "the way people think shapes + 名詞"
+    - "I think that's a good/the best way to + 動詞"
+    - "put what I want to say into English"
+    - "feel disconnected from + 人"
+    - "It makes me wonder if 文"
+    - "come from not having enough knowledge about + 名詞"
+    - "lack confidence in + 名詞"
+
+    ====================
+    INPUT
+    ====================
+    Input text:
+    "#{body}"
+
+    #{output_format}
+    PROMPT
+  end
+
+  private
+
+  attr_reader :body, :tone
+
+  def tone_description
+    case tone
+    when "polite"
+      <<~DESC
+        - polite:
+            Calm, thoughtful, emotionally mature natural American English.
+            Kind, steady, and respectful.
+            Slightly polished, but still simple and human.
+            Use everyday vocabulary, not formal or fancy words.
+            Gentle emotional restraint.
+            Longer smooth sentences are okay.
+            Reserved emotional tone.
+      DESC
+    when "standard"
+      <<~DESC
+        - standard:
+            Warm, natural everyday American English.
+            Honest, balanced, believable.
+            Like a real native American writing privately.
+            Default natural tone.
+      DESC
+    when "casual"
+      <<~DESC
+        - casual:
+            Warm, relaxed, conversational natural American English.
+            More spontaneous and emotionally close.
+            Use simple wording and natural flow.
+            Simple wording should not oversimplify meaning.
+            More immediate and human.
+      DESC
     end
+  end
 
-    private
-
-    attr_reader :body, :tone
-
-    def tone_description
-        case tone
-        when "polite"
-          <<~DESC
-            - polite:
-                Calm, thoughtful, emotionally mature natural American English.
-                Kind, steady, and respectful.
-                Slightly polished, but still simple and human.
-                Use everyday vocabulary, not formal or fancy words.
-                Gentle emotional restraint.
-                Longer smooth sentences are okay.
-                Reserved emotional tone.
-            DESC
-        when "standard"
-          <<~DESC
-            - standard:
-                Warm, natural everyday American English.
-                Honest, balanced, believable.
-                Like a real native American writing privately.
-                Default natural tone.
-             DESC
-        when "casual"
-          <<~DESC
-            - casual:
-                Warm, relaxed, conversational natural American English.
-                More spontaneous and emotionally close.
-                Use simple wording and natural flow.
-                Simple wording should not oversimplify meaning.
-                More immediate and human.
-             DESC
-        end
-    end
-
-    def output_format
-        <<~FORMAT
-            ====================
-            OUTPUT JSON ONLY
-            ====================
-            Do not omit any keys.
-            Return ONLY valid JSON matching this exact structure:
-            {
-                "rewritten_text": "text (required)",
-                "notes":[
+  def output_format
+    <<~FORMAT
+      ====================
+      OUTPUT JSON ONLY
+      ====================
+      Do not omit any keys.
+      Return ONLY valid JSON matching this exact structure:
+      {
+        "rewritten_text": "text (required)",
+        "notes": [
+          {
+            "original_text": "string (required)",
+            "corrected_text": "string (required)",
+            "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
+            "explanation": "text in Japanese (required)",
+            "learning_points": {
+              "label": "短い日本語ラベル。例: 前置詞 to の抜け 動詞の形 語彙選択など",
+              "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environment / make progress with + 名詞 / 動名詞 という形",
+              "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
+              "review_tag": "復習用の短い英語タグ。例: preposition",
+              "related_phrases": [
                 {
-                    "original_text": "string (required)",
-                    "corrected_text": "string (required)",
-                    "mistake_type": "grammar, spelling, word_choice, expression or translation (required)",
-                    "explanation": "text in Japanese (required)",
-                    "learning_points": {
-                    "label": "短い日本語ラベル。例: 前置詞 to の抜け 動詞の形 語彙選択など",
-                    "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environmentという形",
-                    "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
-                    "review_tag": "復習用の短い英語タグ。例: preposition",
-                    "related_phrases":[
-                    {
-                    "phrase": "似たようなネイティブが使う自然な表現",
-                    "meaning": "その表現の意味やニュアンスを日本語で説明",
-                    "example": "完全な英語例文。"
-                    },
-                    {
-                    "phrase": "似たようなネイティブが使う自然な表現",
-                    "meaning": "その表現の意味やニュアンスを日本語で説明",
-                        "example": "完全な英語例文。"
-                    }
-                    ]
-                    }
+                  "phrase": "似たようなネイティブが使う自然な表現",
+                  "meaning": "その表現の意味やニュアンスを日本語で説明",
+                  "example": "完全な英語例文。"
+                },
+                {
+                  "phrase": "似たようなネイティブが使う自然な表現",
+                  "meaning": "その表現の意味やニュアンスを日本語で説明",
+                  "example": "完全な英語例文。"
                 }
-                ]
+              ]
             }
-
-            If the input contains Japanese text, classify all rewriting choices as "translation" type.
-            For each translation note, explain in Japanese why the specific English word or phrase was chosen to express the original Japanese nuance.
-            english_feedback must be based only on THIS text.Be practical, modest, and helpful.
-            If there are no notes, return "notes": []
-           FORMAT
-    end
+          }
+        ]
+      }
+      For each translation note, explain in Japanese why the specific English word or phrase was chosen to express the original Japanese nuance.
+      english_feedback must be based only on THIS text. Be practical, modest, and helpful.
+      If there are no notes, return "notes": []
+    FORMAT
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,11 +26,11 @@
       <p class="font-bold font-sans text-base text-center text-forest-500 sm:text-lg md:text-xl mb-1">
         今日、心が動いたことは？
       </p>
-      <p class="text-center sm:text-base text-forest-600 mb-2">
+      <p class="text-center sm:text-base md:text-lg text-forest-600 mb-2">
         日本語でも英語でも、気持ちを書き残してみよう
       </p>
       <div class="flex justify-center">
-        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64" %>
+        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base md:text-lg" %>
       </div>
     </div>
     <!-- <div class="flex gap-3 mb-4">
@@ -56,17 +56,13 @@
             <p class="font-medium mb-2 text-cream-500 text-base sm:text-lg">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
             </p>
-
-            <!-- <h4 class="font-bold text-ink mb-2">
-            <%# link_to journal.title, journal_path(journal) %>
-            </h4> -->
     
-            <p class="text-ink mb-3 line-clamp-2">
+            <p class="text-ink mb-3 line-clamp-2 text-base md:text-lg">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           
-            <%= link_to journal_path(journal), class: "btn btn-sm bg-forest-500 text-white hover:bg-forest-500 hover:opacity-80" do %>
-            View Details
+            <%= link_to journal_path(journal), class: "btn btn-sm bg-forest-500 text-white hover:bg-forest-500 hover:opacity-80 text-base md:text-lg" do %>
+            この日記を見る
             <% end %>
             </div>
 
@@ -79,7 +75,7 @@
         
         <div class="mt-5 mb-4">
           <%= link_to "すべての日記を見る", journals_path, 
-              class: "btn btn-primary text-white hover: text-forest-300 w-full" %>
+              class: "btn btn-primary text-white hover: text-forest-300 w-full text-base md:text-lg" %>
         </div>
     </div>
   </div>

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -23,7 +23,7 @@
 
         <div class="mb-2">
           <% journal_correction.mistakes.first(2).each do |mistake| %>
-            <p class="font-semibold"><%= mistake.learning_points["pattern"] %></p>
+            <p class="font-semibold text-base md:text-lg"><%= mistake.learning_points["pattern"] %></p>
             <p class="text-gray-500">【意味】<%= mistake.learning_points["meaning"] %></p>
           
             <!--<% if mistake.learning_points["related_phrases"].present? %>

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -8,7 +8,7 @@
     
     
     <div class="flex justify-between gap-2 mb-1">
-      <div class="font-semibold mb-2"> 
+      <div class="font-semibold mb-2 text-base md:text-lg"> 
         <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>
       </div>
       <div class="flex gap-2 mb-2"><% if @previous_journal_correction.present? %>
@@ -71,7 +71,7 @@
                 
                 <%# 学んだ表現 %>
                 <div class="bg-forest-50 p-3 mb-1">
-                  <p class="text-lg font-bold text-forest-700">
+                  <p class="text-lg md:text-2xl font-bold text-forest-700">
                     <%= mistake.learning_points["pattern"] %>
                   </p>
                   <p class="text-forest-600">
@@ -80,28 +80,28 @@
                 </div>
 
                 <%# 添削前・添削後の文章 %>
-                <div class="mx-3 text-gray-500 mb-2">今回の添削</div>
+                <div class="mx-3 text-gray-500 mb-2 text-base md:text-lg">今回の添削</div>
                   <div class="mx-3 bg-red-50 rounded-xl px-2 py-2 mb-2">
-                    <p class=" text-red-500">添削前：<%= mistake.original_text %></p>
+                    <p class=" text-red-500 text-base md:text-lg">添削前：<%= mistake.original_text %></p>
                 </div>
                 <div class="mx-3 bg-forest-50 rounded-xl px-2 py-2">
-                  <p class=" text-forest-600 font-semibold">添削後：<%= mistake.corrected_text %></p> 
+                  <p class=" text-forest-600 font-semibold text-base md:text-lg">添削後：<%= mistake.corrected_text %></p> 
                 </div>
                 <hr class="border-forest-500 mb-2 mt-2">
 
               <%# ほかの表現・言い回し %>
-              <p class="mx-3 text-gray-500 mb-2">似た表現・言い回し</p>
+              <p class="mx-3 text-gray-500 mb-2 text-base md:text-lg">似た表現・言い回し</p>
 
               <% Array(mistake.learning_points["related_phrases"]).compact.each do |phrase| %>
                 <div class="mx-3 bg-white border border-gray-300 rounded-2xl p-3 mb-2">
                   <p class="text-lg font-bold"><%= phrase["phrase"] %></p>
-                  <p><%= phrase["meaning"] %></p>
-                  <p class=" text-forest-500 font-semibold"><%= phrase["example"] %></p>
+                  <p class="text-base md:text-lg"><%= phrase["meaning"] %></p>
+                  <p class=" text-forest-500 font-semibold text-base md:text-lg"><%= phrase["example"] %></p>
                 </div> 
               <% end %>
                 <%= link_to "この日記を見る", 
                     @journal_correction.journal,
-                    class:"mx-3 flex items-center justify-center btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white mb-2" %>                     
+                    class:"text-base md:text-lg mx-3 flex items-center justify-center btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white mb-2" %>                     
                 </div>
             <% end %>  
           </div>

--- a/app/views/journals/_form.html.erb
+++ b/app/views/journals/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: journal do |f| %>
   <%# render 'shared/error_messages', object: f.object %>
   <div class="mb-3">
-    <p class="text-sans text-base font-medium mb-2">今日の気分</p>
+    <p class="text-sans text-base md:text-lg font-medium mb-2">今日の気分</p>
     <div class="border border-gray-300 bg-white rounded-2xl py-3 px-3">
     <div class="flex gap-2">
     <% Journal.moods.each do |key, value| %>
@@ -23,7 +23,7 @@
   </div>
   
   <%# 日付 %>
-  <div class="mb-3">
+  <div class="mb-3 md:text-lg">
     <%= f.label :posted_date, class: "label label-text text-base font-medium" %>
 
     <button type="button"
@@ -66,32 +66,32 @@
     <%= f.label :title, class: "label label-text text-base" %>
     <%= f.text_field :title, class:"input input-bordered w-full" %>
   </div> -->
-  <div class="mb-3">
+  <div class="mb-3 md:text-lg">
     <%= f.label :body, class:"label label-text text-base font-medium" %>
-    <%= f.text_area :body, class: "textarea textarea-bordered w-full text-base", rows: "10", 
+    <%= f.text_area :body, class: "textarea textarea-bordered w-full text-base md:text-lg", rows: "10", 
         placeholder:"今日、心が動いたことは？\n今日の出来事や気持ちを、英語または日本語で自由に書いてみましょう" %>
   </div>
 
   <div class="mb-4">
-  <div class="font-medium text-base mb-2">添削トーン</div>
+  <div class="font-medium text-base md:text-lg mb-2">添削トーン</div>
     <div class="flex gap-4">
       <label class="flex-1">
         <%= f.radio_button :"tone", "polite", class: "hidden peer" %>
-        <span class="btn btn-outline btn-primary w-full peer-checked:bg-forest-500 peer-checked:text-white ">
+        <span class="btn btn-outline btn-primary w-full peer-checked:bg-forest-500 peer-checked:text-white md:text-lg">
         丁寧
         </span>
       </label>
 
       <label class="flex-1">
         <%= f.radio_button :"tone", "standard", class: "hidden peer" %>
-        <span class="btn btn-outline btn-primary w-full peer-checked:bg-forest-500 peer-checked:text-white">
+        <span class="btn btn-outline btn-primary w-full peer-checked:bg-forest-500 peer-checked:text-white md:text-lg">
         スタンダード
         </span>
       </label>
 
       <label class="flex-1">
         <%= f.radio_button :"tone", "casual", class:"hidden peer" %>
-        <span class="btn btn-outline btn-primary w-full peer-checked:bg-forest-500 peer-checked:text-white ">
+        <span class="btn btn-outline btn-primary w-full peer-checked:bg-forest-500 peer-checked:text-white md:text-lg">
         カジュアル
         </span>
       </label>
@@ -99,5 +99,5 @@
       <%# f.submit "カジュアル", name:"tone",value: "casual", class:"btn btn-outline btn-primary flex-1" %>
     </div>
   </div>
-  <%= f.submit "添削する", class:"btn btn-primary w-full mt-4" %>
+  <%= f.submit "添削する", class:"btn btn-primary w-full mt-4 text-base md:text-lg" %>
 <% end %>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -24,11 +24,11 @@
 
           <%= link_to journal_path(journal), class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           
-          <p class="font-bold text-cream-500 mb-3">
+          <p class="font-bold text-cream-500 mb-2">
             <%= journal.posted_date.strftime("%Y/%m/%d") %>
           </p>
 
-          <p class="mb-3 line-clamp-2">
+          <p class="text-base md:text-lg mb-3 line-clamp-2">
             <%= journal.journal_correction&.rewritten_text || journal.body %>
           </p>
           <% end %>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -18,7 +18,7 @@
   </div>
   <%# 元の文章（日本語でもそのまま表示） %>
   <%# スマホ：折りたたみ表示 %>
-    <div class="font-semibold mb-2"><%= @journal.posted_date.strftime("%Y/%m/%d") %></div>
+    <div class="font-semibold mb-2 text-base md:text-lg"><%= @journal.posted_date.strftime("%Y/%m/%d") %></div>
     <div class="md:hidden collapse collapse-arrow border border-cream-300 bg-forest-100 rounded-2xl mb-4">
       <input type="checkbox" />
       <h2 class="collapse-title font-semibold pr-10">元の文章を表示</h2>
@@ -32,9 +32,9 @@
     </div>
   <%# md以上：通常表示 %>
       <div class="hidden md:block border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-      <h2 class="font-semibold mb-2">元の文章 </h2>
+      <h2 class="font-semibold mb-2 text-base md:text-lg">元の文章 </h2>
         <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
-        <p>
+        <p class="text-base md:text-lg">
           <%= @journal_correction&.original_text %>
         </p>
         </div>
@@ -124,7 +124,7 @@
      
 
     <div class="flex mt-5 gap-5">
-    <%= link_to 'ジャーナル一覧に戻る' , journals_path, class:"btn btn-primary flex-1" %>
+    <%= link_to 'ジャーナル一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base md:text-lg" %>
     <%= button_to "このジャーナルを削除",
         journal_path(@journal), method: :delete, form: { data: { turbo_confirm: "このジャーナルを削除しますか?"}}, class: "btn btn-error" %>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,12 +9,12 @@
 <div class="navbar-center hidden md:flex">
   <% if user_signed_in? %>
   <span>
-    <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "学び", journal_corrections_path, class: "btn btn-ghost normal-case text-md" %>
-    <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md" %>
+    <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "学び", journal_corrections_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md md:text-lg" %>
   </span>
   <% else %>
     <%# 未ログイン時は何も表示しない %>
@@ -27,15 +27,15 @@
 <div class="navbar-end gap-2">
   <div class="hidden md:flex gap-2">
       <% if user_signed_in? %>
-        <%= link_to t('.logout'), destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "btn btn-primary font-bold text-white hover:opacity-70" %>
+        <%= link_to t('.logout'), destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "btn btn-primary font-bold text-white hover:opacity-70 text-base md:text-lg" %>
       <% else %>
         <div class = "flex gap-4">
-        <%= link_to t('.register'), new_user_registration_path, class: "btn btn-primary font-bold text-white px-6 text-sm  sm:text-base min-h-11 h-11 hover:opacity-70" %>
+        <%= link_to t('.register'), new_user_registration_path, class: "btn btn-primary font-bold text-white px-6 text-sm  sm:text-base min-h-11 h-11 hover:opacity-70 text-base md:text-lg" %>
       
         <% if current_page?(new_user_session_path) %>
-          <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md px-6 text-sm sm:text-base h-11 min-h-11 opacity-60 pointer-events-none" %>
+          <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md px-6 text-sm sm:text-base h-11 min-h-11 opacity-60 pointer-events-none text-base md:text-lg" %>
         <% else %>
-          <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md px-6 text-sm sm:text-base h-11 min-h-11 hover:opacity-70" %>
+          <%= link_to t('.login'), new_user_session_path, class: "btn btn-outline btn-md px-6 text-sm sm:text-base h-11 min-h-11 hover:opacity-70 text-base md:text-lg" %>
         <% end %>
       <% end %>
         </div>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,134 +1,63 @@
     <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
       <div class="flex items-center gap-2">
-        <h2 class="font-semibold mb-3">添削後の文章</h2>
+        <h2 class="font-semibold mb-3 text-base md:text-lg">添削後の文章</h2>
         <span class="badge badge-soft badge-success text-white mb-3 p-3">
         添削トーン：<%= t("activerecord.attributes.journal.tones.#{@journal_correction.journal.tone}")  %>
         </span>
       </div>
         <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
-          <p>
+          <p class="text-base md:text-lg">
           <%= @journal_correction.rewritten_text %>
           </p>
         </div>
     </div>
 
     <% if @journal_correction.mistakes.present? %>
-      <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-        <div class="flex justify-between mb-3">
-          <h2 class="font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
-           <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-forest-500 text-forest-500 hover:bg-forest-500 hover:text-white" %>
-        </div>
-        <div class="border border-gray-300 bg-white rounded-2xl p-4 mb-2">
-          <ol class="list-decimal list-inside">
-            <% @journal_correction.mistakes.each do |mistake| %>
-              <li class="mb-4">
-                <span class="font-semibold">
+      <div class="flex justify-between items-center mb-3">
+        <h2 class="text-lg md:text-2xl font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
+          <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-forest-500  bg-forest-50 text-forest-500 hover:bg-forest-500 hover:text-white text-base md:text-lg" %>
+      </div>
+
+          <% @journal_correction.mistakes.each do |mistake| %>
+            <%# 枠開始 %>
+            <div class="bg-white border border-gray-200 rounded-2xl overflow-hidden mb-3">
+              <div class="bg-forest-50 border-b border-forest-200 px-4 py-3"> 
+                <span class="badge badge-primary mb-2 p-3">
                   <%= mistake_type_label(mistake.mistake_type) %>
                 </span>
-                <p class="text-base bg-red-50 px-3 py-2 text-red-500 mb-1 rounded-xl">  
-                【添削前】: <%= mistake.original_text %></p>
-                <p class="text-base bg-sage-50 border-l-2 text-forest-600 font-semibold border-forest-200 rounded-xl px-3 py-2">
-                【添削後】：<%= mistake.corrected_text %></p>
+                <% if mistake.learning_points["pattern"].present? %>
+                  <p class="text-lg md:text-2xl font-semibold mb-1 text-forest-600">
+                    <%= mistake.learning_points["pattern"] %>
+                  </p>
+                <% end %>
+                <% if mistake.learning_points["meaning"].present? %>
+                  <p class="text-base md:text-lg text-forest-600">
+                    <%= mistake.learning_points["meaning"] %> 
+                  </p>
+                <% end %>
+                </div>
+                
+                <%# ボディ %>
+                <div class="px-4 py-3">
+                  <p class="text-gray-600 mb-1 text-base md:text-lg">今回の添削</p>
+                  <p class="mx-2 text-base md:text-lg bg-red-50 px-3 py-2 text-red-500 mb-2 rounded-xl">  
+                  <%= mistake.original_text %></p>
+                  <p class="mx-2 text-base md:text-lg bg-sage-50  text-forest-600 font-semibold border-forest-200 rounded-xl px-3 py-2">
+                  <%= mistake.corrected_text %></p>
 
-                <p class="text-base mt-2">ポイント</p>
-                  <div class=" bg-cream-100 rounded-xl px-3 py-2">
-                    <p> <%= mistake.explanation %></p>
-                  </div>
-                <% if mistake.learning_points.present? %>
-                  <div class="text-base bg-white border border-cream-300 rounded-xl px-3 py-2 mt-2">
-                    <!--<% if mistake.learning_points["review_tag"].present? %>
-                      <p>【復習タグ】<%= mistake.learning_points["review_tag"] %>
-                    <% end %> 
-                    <% if mistake.learning_points["label"].present? %>
-                      (<%= mistake.learning_points["label"] %>)
-                    <% end %></p>-->
-                      <% if mistake.learning_points["meaning"].present? %>
-                        <p>【意味・ニュアンス】<%= mistake.learning_points["meaning"] %></p>
-                      <% end %>
-                    <% if mistake.learning_points["pattern"].present? %>
-                      <p>【覚える型】<%= mistake.learning_points["pattern"] %></p>
-                    <% end %>
-
-                    <!--<% if mistake.learning_points["related_phrases"].present? %>
-                      <div class="mt-2">
-                        <p class="font-semibold">似た表現</p>
-                        <% mistake.learning_points["related_phrases"].each do |phrase| %>
-                          <div class="mt-2 bg-sage-50 border-l-2 border-forest-200 px-3 py-2">
-                            <% if phrase["meaning"].present? %>
-                              <p>【意味】<%= phrase["meaning"] %></p>
-                            <% end %>
-
-                            <% if phrase["phrase"].present? %>
-                              <p>【表現】<%= phrase["phrase"] %></p>
-                            <% end %>
-
-                            <% if phrase["example"].present? %>
-                              <p>【例文】<%= phrase["example"] %></p>
-                            <% end %>
-                          </div>
-                        <% end %>
-                      </div>
-                    <% end %> -->
-
+                <%# ポイント %>
+                <% if mistake.explanation.present? %>
+                  <p class="text-gray-600 mt-2 text-base md:text-lg">ポイント</p>
+                  <div class="mx-2 bg-gray-50 rounded-xl px-3 py-2 text-gray-700">
+                    <%= mistake.explanation %>
                   </div>
                 <% end %>
-              </li>
+                </div>
+              </div>
             <% end %>
-          </ol>
-        </div>
-      </div>
+
     <% else %>
       <div class="alert alert-success mb-4">
         <span>🎉 間違いは見つかりませんでした！</span>
       </div>
     <% end %>
-
-    <%# 外側のカード %>
-    <% if @journal_correction&.mistake_patterns.present? || @journal_correction&.native_phrases.present? %>
-      <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-2">
-        <h3 class="font-semibold text-base mb-2">英語表現のポイント</h3>   
-
-        <%# 内側の白部分 %>
-        <!--<div class="border border-gray-100 bg-white rounded-2xl p-4 mb-2"> -->
-          <div class="mb-2">
-
-          <% if @journal_correction&.mistake_patterns.present? %>
-          
-          <div class="mb-2">
-          <p class="badge badge-error p-3 mb-2">間違いパターン</p>
-            
-            <% (@journal_correction.mistake_patterns || []).each do |pattern| %> 
-              <div class="bg-white rounded-2xl p-3 mb-2">
-                <p class="font-semibold"><%= pattern["point"] %></p>
-                <p class="bg-gray-100 px-3 py-2 text-gray-600">【添削前】<%= pattern["evidence"] %></p>
-                <p>【説明】<%= pattern["explanation"] %></p>
-              </div>
-            <% end %>
-          </div>
-          <% end %>
-          </div>
-          
-          <% if @journal_correction&.native_phrases.present? %>
-          <hr class="border-forest-300 mb-2">
-
-          <div class="mb-2">
-            <p class="badge badge-warning p-3 mb-2">ネイティブがよく使う表現</p>
-            
-            <% @journal_correction.native_phrases&.each do |phrase| %>
-            <div class="bg-white rounded-2xl p-3 mb-2">
-              <p>【意味】<%= phrase["meaning"] %></p>
-              <p>【覚えたい表現】<%= phrase["phrase"] %></p>
-              <p>【使い方（文法）】<%= phrase["grammarpattern"] %>
-              <p>【今回の日記では】<%= phrase["corrected_text"] %></p>
-              <p>【ほかの場面では】</p>
-              <p><%= phrase["example"] %></p>
-              <p><%= phrase["example2"] %></p>
-            </div>
-            <% end %>
-          </div>
-          <% end %>
-      <!--</div> -->
-      </div>
-    <% end %>
-
- <!-- </div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
AI添削で返却される `learning_points` の品質を改善するため、プロンプトの指示内容を整理しました。
あわせて、添削結果・学び一覧まわりの表示を見やすく調整しました。

## 背景
なぜこの変更が必要だったか（Issueリンク）

## 変更内容
  - `JournalPromptBuilder` のプロンプトを調整
    - 添削文では意味・感情ニュアンスの保持を優先するよう修正
    - `learning_points.pattern` が広すぎる文法パターンにならないよう指示を追加
    - `so + 形容詞` など、学習価値が低い強調表現を選びにくくするルールを追加
    - `related_phrases` は親の learning point と意味・機能が近い表現に限定するよう整理
    - 
  - 添削結果・学び表示UIを調整
    - 添削後の文章、今回の学び、関連表現の文字サイズを調整
    - `shared/_mistakes_list` の表示構造を整理
    - 学びのカードで pattern / meaning / 添削前後 / ポイントが見やすくなるよう変更
    - ホーム、日記一覧、日記詳細、学び一覧、ヘッダー周りのテキストサイズを調整

## 確認方法
  - [ ] AI添削後、`learning_points.pattern` に広すぎる表現が出にくくなっていること
  - [ ] 添削結果画面で、学びカードが崩れず表示されること
  - [ ] 学び詳細画面で、関連表現が表示されること
  - [ ] ホーム・日記一覧・日記詳細の表示が崩れていないこと

## 関連Issue
closes #