### PR TITLE
fix:ホーム画面・ジャーナル画面のUI修正

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-title font-bold text-2xl sm:text-3xl md:text-4xl mb-6 leading-tight">
+    <h1 class="font-title font-bold text-2xl text-forest-600 sm:text-3xl md:text-4xl mb-6 leading-tight">
     <%= current_user.name %>'s Journal
     </h1>
 
@@ -33,15 +33,6 @@
         <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base md:text-lg" %>
       </div>
     </div>
-    <!-- <div class="flex gap-3 mb-4">
-      <div class="border border-cream-300 bg-white rounded-2xl p-4 flex-1">
-        <p class="font-bold mb-2">今月の投稿数</p>
-        <p class="text-2xl fonto-medium text-forest-500"><%= @monthly_count %></p>
-      </div>
-    </div> -->
-
-    <!-- <div class="container">
-      <div class="col-sm-12 col-lg-4 mb-3"> -->
   
         <h2 class="font-medium font-title text-lg sm:text-2xl md:text-3xl text-center font-cream-500 mb-5">
           Recent Journals
@@ -51,25 +42,28 @@
         
           <% @journals.each do |journal| %>
             <%# 1件ずつ枠で囲む %>
+             <%= link_to journal_path(journal) do %>
             <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-3">
             
-            <p class="font-medium mb-2 text-cream-500 text-base sm:text-lg">
+            <p class="font-medium mb-2 items-center text-cream-500 text-base sm:text-lg flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
+              <span class="inline-flex items-center bg-forest-50 text-forest-500 text-sm md:text-md  rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
     
             <p class="text-ink mb-3 line-clamp-2 text-base md:text-lg">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           
-            <%= link_to journal_path(journal), class: "btn btn-sm bg-forest-500 text-white hover:bg-forest-500 hover:opacity-80 text-base md:text-lg" do %>
+            <!-- <%# link_to journal_path(journal), class: "btn btn-sm border border-forest-500 text-forest-500 hover:bg-forest-500 hover:bg-forest-500 hover:opacity-80 hover:text-white text-base md:text-lg" do %>
             この日記を見る
+            <%# end %> -->
             <% end %>
             </div>
 
           <% end %>
           <% else %>
             <div class="bg-white border border-cream-300 rounded-2xl p-8 text-center">
-              <p class="font-sans text-ink-muted text-xl">日記がありません</p>
+              <p class="font-sans text-ink-muted text-xl">最初の1ページです🌱</p>
             </div>
         <% end %>
         

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -13,10 +13,12 @@
           <%= link_to journal_correction_path(journal_correction),
             class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           <%# 日付 %>
-            <div class="font-bold text-cream-500 flex items-center gap-2">
-              <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
+            <div class="font-bold text-cream-500 flex items-center gap-3 mb-2">
+              <span>
+                <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
+              </span>
               <div class="badge badge-soft badge-success badge-md text-white">
-                <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
+                  <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
               </div>
            </div>
       
@@ -42,8 +44,8 @@
       <div role="alert" class="alert alert-info alert-soft">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-        </svg>
-        <span>まだジャーナリングがありません。最初のジャーナリングを書いてみましょう！</span>
+        </svg>最初の1ページです🌱今日の気持ちを書いてみましょう
+        <span></span>
       </div>
     <% end %>
   </div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -13,34 +13,50 @@
         <%# 日記一覧をループ %>
         <% @journals.each do |journal| %>
           <%#　1件ずつ枠で囲む  %>
-          <div class="text-right">
+          <!--<div class="text-right">
             <%= button_to "削除",
                 journal_path(journal),
                 method: :delete,
                 form: {data: {turbo_confirm:"このジャーナルを削除しますか？"}},
-                class: "text-sm text-center hover:opacity-70"
+                class: "btn btn-sm text-sm text-center hover:opacity-70"
             %>
+          </div>-->
+
+          <div class="border border-cream-300 bg-white rounded-lg py-3 mb-2 px-4">
+
+            <div class="flex items-center gap-3">
+              <span class="font-bold text-cream-500 mb-2">
+                <%= journal.posted_date.strftime("%Y/%m/%d") %>
+              </span>
+              <span class="inline-flex items-center bg-forest-50 text-forest-500 text-sm md:text-md rounded-full px-2 py-1">
+                添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
+              </span>
+              <span class="ml-auto">
+              <%= button_to "削除",
+                  journal_path(journal),
+                  method: :delete,
+                  form: {data: {turbo_confirm:"このジャーナルを削除しますか？"}},
+                  class: "btn btn-sm text-sm text-center bg-gray-200 hover:opacity-70"
+              %>
+            </span>
+            </div>
+            <%# 本文 %>
+            <%= link_to journal_path(journal) do %>
+            <p class="text-base md:text-lg mb-3 line-clamp-2">
+              <%= journal.journal_correction&.rewritten_text || journal.body %>
+            </p>
+            <% end %>
           </div>
 
-          <%= link_to journal_path(journal), class:"block border border-cream-300 bg-white rounded-lg px-2 py-1 sm:px-4 py-3" do %>
-          
-          <p class="font-bold text-cream-500 mb-2">
-            <%= journal.posted_date.strftime("%Y/%m/%d") %>
-          </p>
-
-          <p class="text-base md:text-lg mb-3 line-clamp-2">
-            <%= journal.journal_correction&.rewritten_text || journal.body %>
-          </p>
-          <% end %>
         <% end %>
+
       <% else %>
       <div role="alert" class="alert alert-info">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
         </svg>
-        <span>まだジャーナリングがありません。最初のジャーナルを書いてみましょう！</span>
+        <span>最初の1ページです🌱今日の気持ちを書いてみましょう</span>
       </div>
       <% end %>
     </div>
   </div>
-</div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -18,26 +18,29 @@
   </div>
   <%# 元の文章（日本語でもそのまま表示） %>
   <%# スマホ：折りたたみ表示 %>
-    <div class="font-semibold mb-2 text-base md:text-lg"><%= @journal.posted_date.strftime("%Y/%m/%d") %></div>
-    <div class="md:hidden collapse collapse-arrow border border-cream-300 bg-forest-100 rounded-2xl mb-4">
-      <input type="checkbox" />
-      <h2 class="collapse-title font-semibold pr-10">元の文章を表示</h2>
-      <div class="collapse-content">
-        <div class="border border-cream-300 bg-white rounded-2xl p-4">
-          <p>
-            <%= @journal_correction&.original_text %>
-          </p>
-        </div>
-      </div>
+    <div class="font-semibold mb-2 text-base md:text-lg">
+      <%= @journal.posted_date.strftime("%Y/%m/%d") %>
     </div>
+      <div class="md:hidden collapse collapse-arrow border border-gray-200 bg-white rounded-2xl overflow-hidden mb-4">
+        <input type="checkbox" />
+          <h2 class="collapse-title font-semibold pr-10 bg-red-50 text-red-500">元の文章を表示</h2>
+
+          <div class="collapse-content">
+            <p class="px-2 py-2">
+              <%= @journal_correction&.original_text %>
+            </p>
+          </div>
+      </div>
+
   <%# md以上：通常表示 %>
-      <div class="hidden md:block border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-      <h2 class="font-semibold mb-2 text-base md:text-lg">元の文章 </h2>
-        <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
-        <p class="text-base md:text-lg">
+       <%# 枠開始 %>
+      <div class="hidden md:block border border-gray-200 bg-white rounded-2xl overflow-hidden mb-4">
+        <div class="bg-red-50 border-b border-red-100 px-4">
+          <h2 class="font-semibold text-base md:text-lg text-red-500 py-2">元の文章 </h2>
+        </div>  
+        <p class="text-base md:text-lg px-4 py-3">
           <%= @journal_correction&.original_text %>
         </p>
-        </div>
     </div>
   
     <% if @journal_correction.present? %>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,15 +1,13 @@
-    <div class="border border-cream-300 bg-forest-100 rounded-2xl p-4 mb-4">
-      <div class="flex items-center gap-2">
-        <h2 class="font-semibold mb-3 text-base md:text-lg">添削後の文章</h2>
-        <span class="badge badge-soft badge-success text-white mb-3 p-3">
-        添削トーン：<%= t("activerecord.attributes.journal.tones.#{@journal_correction.journal.tone}")  %>
+    <div class="border border-gray-200 bg-white rounded-2xl mb-4">
+      <div class="flex items-center gap-2 bg-forest-50 border-b border-forest-200 px-4 ">
+        <h2 class="font-semibold text-base md:text-lg py-2 text-forest-600">添削後の文章</h2>
+        <span class="badge badge-soft badge-success text-white  p-3">
+        添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
-        <div class="border border-cream-300 bg-white rounded-2xl p-4 mb-2">
-          <p class="text-base md:text-lg">
+          <p class="text-base md:text-lg p-4">
           <%= @journal_correction.rewritten_text %>
           </p>
-        </div>
     </div>
 
     <% if @journal_correction.mistakes.present? %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -24,3 +24,7 @@ ja:
         good: 良い
         neutral: 普通
         bad: 悪い
+      tone:
+        polite: 丁寧
+        standard: スタンダード
+        casual: カジュアル


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ジャーナル関連画面のUIを調整し、各ジャーナルに添削トーンが表示されるようにしました。


## 変更内容
 - ジャーナル一覧画面のカードUIを調整
  - ジャーナル一覧に添削トーンを表示
  - ジャーナル詳細画面の「元の文章」「添削後の文章」の表示デザインを調整
  - 学び一覧画面のカード表示と空状態メッセージを調整
  - `tone` enum の日本語表示を `config/locales/activerecord/ja.yml` に追加

## 関連Issue
closes #