### PR TITLE
feat:カレンダーページ作成

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -3,7 +3,11 @@ class JournalsController < ApplicationController
   before_action :authenticate_user!
   def index
     # @journals =current_user.journals.order(created_at: :desc)
-    @journals =current_user.journals.includes(:journal_correction).order(posted_date: :desc, id: :desc)
+    @journals =current_user.journals.includes(:journal_correction)
+      if params[:posted_date].present?
+        @journals = @journals.where(posted_date: params[:posted_date])
+      end
+    @journals = @journals.order(posted_date: :desc, id: :desc)
   end
 
   def show
@@ -129,6 +133,28 @@ class JournalsController < ApplicationController
     @journal = current_user.journals.find(params[:id])
     @journal.destroy
     redirect_to journals_path, success: "ジャーナルが削除されました。", status: :see_other
+  end
+
+  def calendar
+    @year = params[:year]&.to_i || Date.current.year
+    @month = params[:month]&.to_i || Date.current.month
+    first_of_month = Date.new(@year, @month, 1)
+    last_of_month = first_of_month.end_of_month
+
+    @calendar_start = first_of_month.beginning_of_week(:monday)
+    @calendar_end = last_of_month.end_of_week(:monday)
+
+    prev = first_of_month.prev_month
+    nxt = first_of_month.next_month
+    @prev_year, @prev_month = prev.year, prev.month
+    @next_year, @next_month = nxt.year, nxt.month
+
+    @journals_by_date = current_user
+                        .journals
+                        .where(posted_date: @calendar_start..@calendar_end)
+                        .order(posted_date: :desc, id: :desc)
+                        .group_by(&:posted_date)
+    @today = Date.current
   end
 
   private

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     <h1 class="font-semibold font-sans text-lg md:text-4xl sm:text-2xl text-center mb-6">
-    学び一覧
+     <%= t('.title') %>
     </h1>
 
     <% if @journal_corrections.any? %>

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -1,0 +1,68 @@
+<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+  <div class="max-w-5xl mx-auto w-full pt-2 pb-6 sm:pt-6 md:px-2">
+    <div class="w-full bg-white/80 p-4 sm:p-6 rounded-3xl">
+    
+    <div class="flex items-center justify-between flex-wrap">
+      <h1 class="text-lg sm:text-cl md:text-2xl font-semibold text-forest-500">
+        ジャーナルカレンダー
+        <span class="text-forest-500 text-sm sm:text-base md:text-2xl">(<%= @year %>年 <%= @month %>月)</span>
+      </h1>
+      <div class="flex items-center gap-2 flex-wrap text-xs sm:text-sm">
+        <%= link_to "前月", calendar_journals_path(year: @prev_year, month: @prev_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-forest-100 text-forest-500 font-semibold hover:bg-forest-200" %>
+        <%= link_to "今月", calendar_journals_path(year: @today.year, month: @today.month), class:"px-4 py-2 rounded-xl border border-forest-500 bg-forest-500 text-white font-semibold hover:bg-forest-600" %>
+        <%= link_to "翌月", calendar_journals_path(year:@next_year, month:@next_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-forest-100 text-forest-500 font-semibold hover:bg-forest-200" %>
+      </div>
+    </div>
+
+    <!-- 曜日 -->
+    <div class="mt-4 grid grid-cols-7 gap-2 text-center text-sm sm:text-base md:text-lg">
+      <% [ "月", "火", "水", "木", "金", "土", "日"].each do |day| %>
+        <div class="px-2 py-1 text-center font-medium text-forest-500">
+          <%= day %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- カレンダー本体 -->
+    <div class="mt-1 grid grid-cols-7 gap-2 ">
+      <% day = @calendar_start %>
+      <% while day <= @calendar_end %>
+        <% journals = @journals_by_date[day] || [] %>
+
+        <!-- 日記が1件の場合 -->
+        <% if journals.size == 1 %>
+          <%= link_to journal_path(journals.first), 
+              class:"group block min-h-28 rounded  bg-forest-500/80 px-3 py-3 rounded text-left hover:bg-gray-200" do %>
+          <div class="font-semibold text-white group-hover:text-forest-400" >
+          <%= day.day %>
+          <span class="text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
+          </div>
+          <% end %>
+
+        <!-- 日記が2件以上の場合-->
+        <% elsif journals.size > 1 %>
+          <%= link_to journals_path(posted_date: day), 
+              class:"group block min-h-28 rounded  bg-forest-500/80 px-3 py-3  text-left hover:bg-gray-200" do %>
+            <div class="font-semibold text-white group-hover:text-forest-400">
+            <%= day.day %>
+            <span class="text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
+            </div>
+          <% end %>
+        <% else %>
+
+          <!-- 日記がない日 -->
+          <%= link_to new_journal_path(posted_date: day), 
+              class:"group block min-h-28 rounded  bg-gray-100 px-3 py-3  text-left text-forest-400 hover:bg-gray-200" do %>
+            <div class="font-semibold group-hover:text-forest-400">
+            <%= day.day %>
+            </div>
+          <% end %>
+        <% end %>
+
+        <% day += 1.day %>
+      <% end %>
+    </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,8 +12,8 @@
     <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
     <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
     <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
-    <%= link_to "カレンダー", "#", class: "btn btn-ghost normal-case text-md md:text-lg" %>
-    <%= link_to "学び", journal_corrections_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
     <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md md:text-lg" %>
   </span>
   <% else %>
@@ -53,8 +53,8 @@
         <li><%= link_to "ホーム", authenticated_root_path %></li>
         <li><%= link_to "日記を書く", new_journal_path %></li>
         <li><%= link_to "ジャーナル一覧", journals_path %></li>
-        <li><%= link_to "カレンダー", "#" %></li>
-        <li><%= link_to "学び", journal_corrections_path %></li>
+        <li><%= link_to "カレンダー", calendar_journals_path %></li>
+        <li><%= link_to "表現一覧", journal_corrections_path %></li>
         <li><%= link_to "マイページ", "#" %></li>
         <li>
           <%= link_to t('.logout'), destroy_user_session_path,

--- a/app/views/top/_main.html.erb
+++ b/app/views/top/_main.html.erb
@@ -1,5 +1,5 @@
 <section class="relative overflow-hidden bg-sage-50 min-h-screen
-flex items-center justify-center py-16 px-10">
+flex items-center justify-center py-16 px-5 md:px-10">
    <%# ── 背景アイコン：星と本を薄く散らす ── %>
   <svg class="absolute inset-0 w-full h-full pointer-events-none"
        viewBox="0 0 900 420" xmlns="http://www.w3.org/2000/svg"
@@ -43,30 +43,30 @@ flex items-center justify-center py-16 px-10">
   </svg>
 
   <%# ── メインコンテンツ ── %>
-  <div class="relative z-10 text-center max-w-2xl">
+  <div class="relative z-10 text-center max-w-4xl">
     <!-- <h1 class="font-title text-5xl mb-4">Capture Your Day</h1> -->
-    <span class="inline-block text-lg font-medium tracking-widest
+    <span class="inline-block text-lg md:text-2xl font-medium tracking-widest
                  text-forest-600 bg-white/80 px-4 py-1 rounded-full mb-6">
       AI English Journal
     </span>
     <%# メインキャッチコピー %>
-    <h1 class="font-sans text-3xl md:text-5xl font-normal text-forest-800 leading-snug mb-4">
+    <h1 class="font-sans text-3xl md:text-6xl font-normal text-forest-800 leading-snug mb-4">
       英語で、<br>
       自分の気持ちを表現しよう。
     </h1>
 
     <%# サブコピー %>
-    <p class="text-base text-forest-400 leading-relaxed mb-9">
+    <p class="text-base md:text-2xl text-forest-400 leading-relaxed mb-9">
       完璧な英文より、続ける一文を。<br>
       毎日の小さな一文が自信につながる。<br>
     </p>
     <%# CTAボタン群 %>
     <div class="flex gap-3 justify-center items-center flex-wrap">
       <%= link_to "日記を書く →", new_user_registration_path,
-          class: "btn btn-lg bg-forest-500 text-white border-none hover:bg-forest-600 px-8" %>
+          class: "btn btn-md md:btn-lg  md:text-lg bg-forest-500 text-white border-none hover:bg-forest-600 px-8" %>
 
       <%= link_to "ログインはこちら", new_user_session_path,
-          class: "btn btn-lg bg-white text-center text-forest-600 border-none hover:bg-cream-50" %>
+          class: "btn btn-md md:btn-lg md:text-lg bg-white text-center text-forest-600 border-none hover:bg-cream-50" %>
     </div>
   </div>
 </section>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -11,9 +11,10 @@ ja:
   #   label:
   #     email: メールアドレス
   #     password: パスワード
-  # user_sessions:
-  #   new:
-  #     title: ログイン
+
+  # home:
+  #   index:
+  #     title: ホーム
   registrations:
     new:
         # title: 新規登録
@@ -24,11 +25,15 @@ ja:
       title: ジャーナリング作成
     show:
       title: ジャーナル添削結果
+    index:
+      title: ジャーナリング一覧
+    calendar:
+      title: カレンダー
   journal_corrections:
     index:
-      title: 学び一覧
+      title: 表現一覧
     show:
-      title: 学び詳細
+      title: 表現詳細
   shared:
     header:
       login: ログイン

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,12 @@ Rails.application.routes.draw do
 
   # root "top#index"
   # root to "home#index"
-  resources :journals, only: [ :index, :show, :new, :create, :edit, :update, :destroy ]
+  resources :journals, only: [ :index, :show, :new, :create, :edit, :update, :destroy ] do
+    collection do
+      get "calendar"
+    end
+  end
+
   resources :mistakes, only: [ :index, :show, :new, :create, :destroy ]
   resource :user, only: [ :show, :edit, :update, :destroy ]
   resources :journal_corrections, only: [ :index, :show ]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ジャーナルを月別カレンダーで確認できる画面を追加しました。

## 変更内容
- JournalsControllerにcalendar アクションを追加
 - routes.rbにcalendar_journals_pathのルーティングを追加
 - ジャーナルカレンダー画面を追加
    - 前月 / 今月 / 翌月への移動
    - 日記がある日の色分け表示
    - ジャーナル1件の日は詳細画面へ遷移
    - ジャーナル複数件の日は日付で絞り込んだジャーナル一覧画面へ遷移
    - 未記入の日は新規作成画面へ遷移
  - 「学び」表記を「表現一覧」に変更

## 確認方法

- [ ]   カレンダー画面が表示されること
- [ ]    前月 / 今月 / 翌月のリンクで月移動できること
- [ ]   日記が1件ある日をクリックすると詳細画面へ遷移すること
- [ ]   同じ日に複数件ある日をクリックすると、その日のジャーナル一覧へ遷移すること
- [ ]   日記がない日をクリックすると新規作成画面へ遷移すること
- [ ]   ヘッダーの「カレンダー」リンクからカレンダー画面へ遷移できること

## 関連Issue
closes #138 
closes #139