### PR TITLE
feat:ローディング画面作成

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -27,3 +27,69 @@ body {
   [popover]:not(:popover-open) {
     display: none;
   }
+
+  /* ローディング画面全体 */
+.ai-loading {
+    display: none; /*  最初は非表示 */
+    position: fixed;
+    inset: 0;  /* 上下左右すべて 0 にして画面いっぱいに広げる */
+    z-index: 1000; /* 他の要素より手前に表示する。*/
+    background: rgba(255, 255, 255, 0.85);
+    text-align: center;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+  }
+
+/* 添削ボタンを押すと、JSでis-activeが追加される*/  
+.ai-loading.is-active {
+   display: flex;
+}
+
+.ai-loading-text {
+  margin-top: 32px;
+  font-weight: 600;
+  color: #3ea05c;
+}
+
+.spinner {
+  margin: 100px auto 0;
+  width: 70px;
+  text-align: center;
+}
+
+.spinner > div {
+  width: 18px;
+  height: 18px;
+  background-color: #333;
+
+  border-radius: 100%;
+  display: inline-block;
+  -webkit-animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+  animation: sk-bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce1 {
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+
+.spinner .bounce2 {
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+
+@-webkit-keyframes sk-bouncedelay {
+  0%, 80%, 100% { -webkit-transform: scale(0) }
+  40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes sk-bouncedelay {
+  0%, 80%, 100% { 
+    -webkit-transform: scale(0);
+    transform: scale(0);
+  } 40% { 
+    -webkit-transform: scale(1.0);
+    transform: scale(1.0);
+  }
+}

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,7 @@
+import {  Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  show () {
+    document.getElementById("ai-loading").classList.add("is-active")
+  }
+}

--- a/app/views/journals/_form.html.erb
+++ b/app/views/journals/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: journal do |f| %>
+<%= form_with model: journal, data: { controller: "loading", action: "submit->loading#show" } do |f| %>
   <%# render 'shared/error_messages', object: f.object %>
   <div class="mb-3">
     <p class="text-sans text-base md:text-lg font-medium mb-2">今日の気分</p>
@@ -99,5 +99,18 @@
       <%# f.submit "カジュアル", name:"tone",value: "casual", class:"btn btn-outline btn-primary flex-1" %>
     </div>
   </div>
-  <%= f.submit "添削する", class:"btn btn-primary w-full mt-4 text-base md:text-lg" %>
+  <%= f.submit "添削する",
+      class:"btn btn-primary w-full mt-4 text-base md:text-lg",
+      data: { loading_target: "submit" } %>
+  <div id="ai-loading"  class="ai-loading" aria-hidden="true" >
+    <div class="ai-loading-content">
+      <p class="ai-loading-text">AI添削中</p>
+
+    <div class="spinner">
+      <div class="bounce1"></div>
+      <div class="bounce2"></div>
+      <div class="bounce3"></div>
+    </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -26,9 +26,7 @@
           <h2 class="collapse-title font-semibold pr-10 bg-red-50 text-red-500">元の文章を表示</h2>
 
           <div class="collapse-content">
-            <p class="px-2 py-2">
-              <%= @journal_correction&.original_text %>
-            </p>
+            <p class="px-2 py-2 whitespce-pre-line"><%= @journal_correction&.original_text %></p>
           </div>
       </div>
 
@@ -38,9 +36,7 @@
         <div class="bg-red-50 border-b border-red-100 px-4">
           <h2 class="font-semibold text-base md:text-lg text-red-500 py-2">元の文章 </h2>
         </div>  
-        <p class="text-base md:text-lg px-4 py-3">
-          <%= @journal_correction&.original_text %>
-        </p>
+        <p class="text-base md:text-lg px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
     </div>
   
     <% if @journal_correction.present? %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,11 +9,11 @@
 <div class="navbar-center hidden md:flex">
   <% if user_signed_in? %>
   <span>
-    <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
-    <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
-    <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
-    <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
-    <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
+    <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
+    <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
+    <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
+    <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md md:text-lg" %>
   </span>
   <% else %>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,13 +1,11 @@
     <div class="border border-gray-200 bg-white rounded-2xl mb-4">
       <div class="flex items-center gap-2 bg-forest-50 border-b border-forest-200 px-4 ">
         <h2 class="font-semibold text-base md:text-lg py-2 text-forest-600">添削後の文章</h2>
-        <span class="badge badge-soft badge-success text-white  p-3">
+        <span class="badge badge-soft badge-success text-white px-5 py-4">
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
-          <p class="text-base md:text-lg p-4">
-          <%= @journal_correction.rewritten_text %>
-          </p>
+          <p class="text-base md:text-lg px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
     </div>
 
     <% if @journal_correction.mistakes.present? %>

--- a/app/views/top/_main.html.erb
+++ b/app/views/top/_main.html.erb
@@ -50,7 +50,7 @@ flex items-center justify-center py-16 px-5 md:px-10">
       AI English Journal
     </span>
     <%# メインキャッチコピー %>
-    <h1 class="font-sans text-3xl md:text-6xl font-normal text-forest-800 leading-snug mb-4">
+    <h1 class="font-sans text-3xl sm: text-4xl md:text-5xl font-normal text-forest-800 leading-snug mb-4">
       英語で、<br>
       自分の気持ちを表現しよう。
     </h1>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
「添削する」ボタンを押下後、添削結果が表示されるまでの待機時間にローディング画面を表示するようにしました。

## 変更内容
- ジャーナル作成フォームにローディング表示を追加
  - 「添削する」ボタンを押下後、「AI添削中」の文言とスピナーを表示
  - 画面全体に半透明の白背景を重ねて、 処理中であることを分かりやすく表示

 - ローディング用CSSを追加
    - 初期状態では非表示
    - `is-active` 付与時に表示
    - アニメーションを追加
    
## 確認方法
  - [ ] ジャーナル作成画面で「添削する」を押すとローディング画面が表示される
  - [ ] AI添削完了後、詳細画面へ遷移する

## 関連Issue
closes #141 