### PR TITLE
feat:LINE Messaging APIのWebhook受信用エンドポイントを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "devise-i18n"
 gem "resend"
 
 gem "ruby-openai"
+# LNE Messaging API
+gem 'line-bot-api'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "resend"
 
 gem "ruby-openai"
 # LNE Messaging API
-gem 'line-bot-api'
+gem "line-bot-api"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,9 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
+    line-bot-api (2.7.0)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.25.1)
@@ -403,6 +406,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   letter_opener_web (~> 3.0)
+  line-bot-api
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3, >= 7.2.3.1)
@@ -471,6 +475,7 @@ CHECKSUMS
   launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
   letter_opener (1.10.0) sha256=2ff33f2e3b5c3c26d1959be54b395c086ca6d44826e8bf41a14ff96fdf1bdbb2
   letter_opener_web (3.0.0) sha256=3f391efe0e8b9b24becfab5537dfb17a5cf5eb532038f947daab58cb4b749860
+  line-bot-api (2.7.0) sha256=f6638b40e77fd58696c21204ccbe2eab107fea4f6b039d7c340174fe27e2b047
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04

--- a/app/controllers/line_webhooks_controller.rb
+++ b/app/controllers/line_webhooks_controller.rb
@@ -1,0 +1,7 @@
+class LineWebhooksController < ApplicationController
+  skip_before_action :verify_authemticity_token
+
+  def create
+    head :ok
+  end
+end

--- a/app/controllers/line_webhooks_controller.rb
+++ b/app/controllers/line_webhooks_controller.rb
@@ -1,5 +1,5 @@
 class LineWebhooksController < ApplicationController
-  skip_before_action :verify_authemticity_token
+  skip_before_action :verify_authenticity_token
 
   def create
     head :ok

--- a/app/controllers/line_webhooks_controller.rb
+++ b/app/controllers/line_webhooks_controller.rb
@@ -1,4 +1,5 @@
 class LineWebhooksController < ApplicationController
+  skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
 
   def create

--- a/app/helpers/line_webhooks_helper.rb
+++ b/app/helpers/line_webhooks_helper.rb
@@ -1,0 +1,2 @@
+module LineWebhooksHelper
+end

--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -53,7 +53,7 @@ class JournalPromptBuilder
     - Do not return it as one long paragraph.
     - Preserve the user's original paragraph breaks when possible.
     - If the corrected text has multiple logical sentences or paragraphs, include newline characters (\n) between them.
-    
+
     TONE:
     #{tone}
     #{tone_description}

--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -49,7 +49,11 @@ class JournalPromptBuilder
     - adding slang or trendy expressions (e.g., "no-no", "like, what?")
     - making the writing more dramatic than the original
 
-
+    For rewritten_text:
+    - Do not return it as one long paragraph.
+    - Preserve the user's original paragraph breaks when possible.
+    - If the corrected text has multiple logical sentences or paragraphs, include newline characters (\n) between them.
+    
     TONE:
     #{tone}
     #{tone_description}

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -26,7 +26,7 @@
           <h2 class="collapse-title font-semibold pr-10 bg-red-50 text-red-500">元の文章を表示</h2>
 
           <div class="collapse-content">
-            <p class="px-2 py-2 whitespce-pre-line"><%= @journal_correction&.original_text %></p>
+            <p class="px-2 py-2 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
           </div>
       </div>
 

--- a/app/views/line_webhooks/create.html.erb
+++ b/app/views/line_webhooks/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">LineWebhooks#create</h1>
+  <p>Find me in app/views/line_webhooks/create.html.erb</p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "line_webhooks/create"
   get "home/index"
   devise_for :users
   # これで以下のようなルーティングが自動生成される
@@ -35,6 +36,9 @@ Rails.application.routes.draw do
   # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+
+  # LINE Messaging API
+  post "line/webhook", to: "line_webhooks#create"
 
   # Defines the root path route ("/")
   # root "posts#index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get "line_webhooks/create"
   get "home/index"
   devise_for :users
   # これで以下のようなルーティングが自動生成される

--- a/test/controllers/line_webhooks_controller_test.rb
+++ b/test/controllers/line_webhooks_controller_test.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
 class LineWebhooksControllerTest < ActionDispatch::IntegrationTest
-  test "should get create" do
-    get line_webhooks_create_url
+  test "should receive webhook" do
+    post line_webhook_url
     assert_response :success
   end
 end

--- a/test/controllers/line_webhooks_controller_test.rb
+++ b/test/controllers/line_webhooks_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class LineWebhooksControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get line_webhooks_create_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
LINE Messaging APIのWebhookを受信するためのエンドポイントを追加しました。

## 変更内容
  - `POST /line/webhook` のルーティングを追加
  - `LineWebhooksController#create` を追加
  - LINEプラットフォームからのWebhookリクエストに対して `200 OK` を返すように実装
  - Webhook受信用エンドポイントのコントローラテストを追加

## 関連Issue
closes #169