### PR TITLE
feat:RailsユーザーとLINEユーザーIDの紐づけ

### DIFF
--- a/app/controllers/line_connections_controller.rb
+++ b/app/controllers/line_connections_controller.rb
@@ -1,0 +1,22 @@
+class LineConnectionsController < ApplicationController
+  before_action :authenticate_user!
+  def show
+  end
+  # LINE連携ページとして使う
+  # 連携コードを発行する
+  def create
+    current_user.update!(
+      line_link_code: SecureRandom.hex(3)
+    )
+    redirect_to line_connection_path, notice:"連携コードを発行しました"
+  end
+
+  def destroy
+    current_user.update!(
+      line_user_id: nil,
+      line_link_code: nil,
+      line_notifications_enabled: false
+    )
+    redirect_to line_connection_path, notice: "LINE連携を解除しました"
+  end
+end

--- a/app/controllers/line_connections_controller.rb
+++ b/app/controllers/line_connections_controller.rb
@@ -8,7 +8,7 @@ class LineConnectionsController < ApplicationController
     current_user.update!(
       line_link_code: SecureRandom.hex(3)
     )
-    redirect_to line_connection_path, notice:"連携コードを発行しました"
+    redirect_to line_connection_path, notice: "連携コードを発行しました"
   end
 
   def destroy

--- a/app/controllers/line_logins_controller.rb
+++ b/app/controllers/line_logins_controller.rb
@@ -1,0 +1,114 @@
+require "net/http"
+require "uri"
+require "json"
+require "securerandom"
+class LineLoginsController < ApplicationController
+before_action :authenticate_user!
+
+  # LINE連携開始
+  def new
+    # CSRF対策用のランダムの字列
+    state = SecureRandom.hex(16)
+
+    # callback時に照合するため、sessionに保存する
+    session[:line_login_state] = state
+
+    # LINE Loginの許可URLに渡すパラメータ
+    query = {
+      response_type: "code",
+      client_id: ENV.fetch("LINE_LOGIN_CHANNEL_ID"),
+      redirect_uri: ENV.fetch("LINE_LOGIN_CALLBACK_URL"),
+      state: state,
+      scope: "profile openid",
+      bot_prompt: "normal"
+    }
+
+    # LINEの許可URLを作る
+    line_authorize_url =  "https://access.line.me/oauth2/v2.1/authorize?#{query.to_query}"
+
+    # LINEの許可画面へ移動する
+    redirect_to line_authorize_url, allow_other_host: true
+  end
+
+  # LINE認証・許可後に戻ってくる処理
+  def callback
+    # stateが一致しない場合、不正なアクセスとして止める
+    unless params[:state] == session.delete(:line_login_state)
+        redirect_to root_path, alert: "LINE連携に失敗しました。もう一度お試しください。"
+        return
+  end
+
+  # LINEから返ってきた認可コード
+  code = params[:code]
+
+  # 認可コードをアクセストークン・IDトークンに交換する
+  token_response = fetch_line_token(code)
+  access_token = token_response["access_token"]
+  id_token = token_response["id_token"]
+
+  # IDトークンを検証し、LINEユーザーIDを取得する
+  profile = verify_id_token(id_token)
+  line_user_id = profile["sub"]
+
+  # 公式LINEを友達追加しているか確認する
+  friendship_status = fetch_friendship_status(access_token)
+  line_friend = friendship_status["friendFlag"]
+
+  # RailsのログインユーザーにLINE情報を保存する
+  current_user.update!(
+    line_user_id: line_user_id,
+    line_friend: line_friend,
+    line_notifications_enabled: line_friend
+  )
+
+  redirect_to line_connection_path, notice:"LINE連携が完了しました"
+  rescue => e
+    Rails.logger.error("[LINE Login Error] #{e.class}: #{e.message}")
+    redirect_to line_connection_path, alert: "LINE連携に失敗しました"
+  end
+
+  private
+
+  # 認可コードをLINEのアクセストークンに交換する
+  def fetch_line_token(code)
+    uri = URI.parse("https://api.line.me/oauth2/v2.1/token")
+    response = Net::HTTP.post_form(
+      uri,
+      {
+        grant_type: "authorization_code",
+        code: code,
+        redirect_uri: ENV.fetch("LINE_LOGIN_CALLBACK_URL"),
+        client_id: ENV.fetch("LINE_LOGIN_CHANNEL_ID"),
+        client_secret: ENV.fetch("LINE_LOGIN_CHANNEL_SECRET")
+      }    
+    )
+    JSON.parse(response.body)
+  end
+
+  # IDトークンを検証して、LINEユーザー情報を取得する
+  def verify_id_token(id_token)
+    uri = URI.parse("https://api.line.me/oauth2/v2.1/verify")
+    response = Net::HTTP.post_form(
+      uri,
+      {
+        id_token: id_token,
+        client_id: ENV.fetch("LINE_LOGIN_CHANNEL_ID")
+      }
+    )
+
+    JSON.parse(response.body)
+  end
+
+  # 公式LINEを友達に追加しているか確認する
+  def fetch_friendship_status(access_token)
+    uri = URI.parse("https://api.line.me/friendship/v1/status")
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{access_token}"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+  JSON.parse(response.body)
+  end
+end

--- a/app/controllers/line_logins_controller.rb
+++ b/app/controllers/line_logins_controller.rb
@@ -36,7 +36,7 @@ before_action :authenticate_user!
     unless params[:state] == session.delete(:line_login_state)
         redirect_to root_path, alert: "LINE連携に失敗しました。もう一度お試しください。"
         return
-  end
+    end
 
   # LINEから返ってきた認可コード
   code = params[:code]
@@ -61,7 +61,7 @@ before_action :authenticate_user!
     line_notifications_enabled: line_friend
   )
 
-  redirect_to line_connection_path, notice:"LINE連携が完了しました"
+  redirect_to line_connection_path, notice: "LINE連携が完了しました"
   rescue => e
     Rails.logger.error("[LINE Login Error] #{e.class}: #{e.message}")
     redirect_to line_connection_path, alert: "LINE連携に失敗しました"
@@ -80,7 +80,7 @@ before_action :authenticate_user!
         redirect_uri: ENV.fetch("LINE_LOGIN_CALLBACK_URL"),
         client_id: ENV.fetch("LINE_LOGIN_CHANNEL_ID"),
         client_secret: ENV.fetch("LINE_LOGIN_CHANNEL_SECRET")
-      }    
+      }
     )
     JSON.parse(response.body)
   end

--- a/app/controllers/line_webhooks_controller.rb
+++ b/app/controllers/line_webhooks_controller.rb
@@ -35,7 +35,7 @@ class LineWebhooksController < ApplicationController
       Rails.logger.info "message_text: #{message_text}"
       Rails.logger.info "line_user_id: #{line_user_id}"
 
-      #line_link_code一致ユーザー検索
+      # line_link_code一致ユーザー検索
       user = User.find_by(
         line_link_code: message_text
       )

--- a/app/controllers/line_webhooks_controller.rb
+++ b/app/controllers/line_webhooks_controller.rb
@@ -2,7 +2,63 @@ class LineWebhooksController < ApplicationController
   skip_before_action :authenticate_user!
   skip_before_action :verify_authenticity_token
 
+  # LINEサーバーからWebhookが届いた時の処理
+  # LINEで送られたコードを受け取ってUserと紐づける
   def create
+    Rails.logger.info "LINEからWebhook来た!"
+    # event = params[:events][0]
+    # Rails.logger.info event["message"]["text"]
+
+    body = request.body.read
+    Rails.logger.info body
+
+    # LINEの署名確認
+    signature = request.env["HTTP_X_LINE_SIGNATURE"]
+
+    events = parser.parse(body: body, signature: signature)
+
+    events.each do |event|
+      # # LINEの中身確認
+      # Rails.logger.info event.class
+      # # user_id取得
+      # Rails.logger.info event.source.user_id
+      # if event.is_a?(LINE::Bot::V2::Webhook::MessageEvent)
+      #   Rails.logger.info event.message.text
+      # end
+
+      # MessageEvent以外はスキップ
+      next unless event.is_a?(Line::Bot::V2::Webhook::MessageEvent)
+      message_text = event.message.text
+      # LINEのuser_id
+      line_user_id = event.source.user_id
+
+      Rails.logger.info "message_text: #{message_text}"
+      Rails.logger.info "line_user_id: #{line_user_id}"
+
+      #line_link_code一致ユーザー検索
+      user = User.find_by(
+        line_link_code: message_text
+      )
+
+      # 見つからなければ終了
+      next unless user
+
+      user.update!(
+        line_user_id: line_user_id,
+        line_notifications_enabled: true
+      )
+
+      Rails.logger.info "LINE連携成功"
+    end
+
     head :ok
+  end
+
+  private
+
+  def parser
+    @parser ||= Line::Bot::V2::WebhookParser.new(
+      channel_secret: Rails.application.credentials.dig(:line, :channel_secret)
+    )
   end
 end

--- a/app/controllers/mypages_controller.rb
+++ b/app/controllers/mypages_controller.rb
@@ -1,0 +1,4 @@
+class MypagesController < ApplicationController
+  def show
+  end
+end

--- a/app/helpers/line_connections_helper.rb
+++ b/app/helpers/line_connections_helper.rb
@@ -1,0 +1,2 @@
+module LineConnectionsHelper
+end

--- a/app/helpers/line_logins_helper.rb
+++ b/app/helpers/line_logins_helper.rb
@@ -1,0 +1,2 @@
+module LineLoginsHelper
+end

--- a/app/helpers/mypages_helper.rb
+++ b/app/helpers/mypages_helper.rb
@@ -1,0 +1,2 @@
+module MypagesHelper
+end

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -1,0 +1,29 @@
+<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-4xl text-center mb-6">
+      <%= t('.title') %>
+    </h1>
+
+  <p class="mb-6 text-gray-600 text-center">
+    LINEアカウントを連携すると、週ごとの振り返りレポートや学習のヒントをLINEで受け取れます。
+  </p>
+
+    <div class="card bg-base-200 shadow mb-6 p-5">
+      <% if current_user.line_user_id.present? %>
+        <div class="alert alert-success mb-4">LINEアカウント連携しました!</div>
+        <%= link_to "LINEアカウントを連携する",
+                  line_login_path,
+                  class: "btn w-full bg-gray-400 text-white mb-5" %>  
+        <%= link_to "もう一度LINE連携を確認する", line_login_path, class: "btn w-full bg-[#06C755] text-white" %>
+      <% else %>
+        <%= link_to "LINEアカウントを連携する",
+                  line_login_path,
+                  class: "btn w-full bg-[#06C755] text-white border-[#06C755] mb-5" %>
+        <p class="text-sm text-gray-600">
+        LINEアカウント連携完了しています。<br>LINE通知を受け取るには、公式LINEを友だち追加し、ブロックしている場合は解除してください。
+        </p>
+          <%= link_to "もう一度LINE連携を確認する", line_login_path, class: "btn w-full bg-[#06C755] text-white" %>
+      <% end %>
+</div>
+

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,0 +1,37 @@
+<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6">
+      <%= t('.title') %>
+    </h1>
+      <div class="card bg-base-200 shadow mb-4 p-3">
+        <h2 class="card-title">プロフィール</h2>
+        <div class="flex flex-col gap-2 text-md sm:text-lg md:text-lg">
+          <p>名前：<%= current_user.name %></p>
+          <p>メールアドレス：<%= current_user.email %></p>
+        </div>
+      </div>
+
+      <%= link_to line_connection_path, class:"card bg-base-200 shadow mb-4 p-3 hover:bg-base-300 transition" do %>
+        <h2 class="card-title">LINE連携</h2>
+      <% end %>
+
+      <div class="card bg-base-200 shadow mb-4 p-3">
+        <h2 class="card-title">リマインダー通知設定</h2>
+      </div>
+
+      <div class="card bg-base-200 shadow mb-4 p-3">
+        <h2 class="card-title">利用規約</h2>
+      </div>
+
+      <div class="card bg-base-200 shadow mb-4 p-3">
+        <h2 class="card-title">サービスポリシー</h2>
+      </div>
+
+      <div class="card bg-base-200 shadow mb-4 p-3">
+        <h2 class="card-title">お問い合わせ</h2>
+      </div>
+      
+  </div>
+</div>
+

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -14,7 +14,7 @@
     <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
-    <%= link_to "マイページ", "#", class: "btn btn-ghost normal-case text-md md:text-lg" %>
+    <%= link_to "マイページ", mypage_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
   </span>
   <% else %>
     <%# 未ログイン時は何も表示しない %>
@@ -55,7 +55,7 @@
         <li><%= link_to "ジャーナル一覧", journals_path %></li>
         <li><%= link_to "カレンダー", calendar_journals_path %></li>
         <li><%= link_to "表現一覧", journal_corrections_path %></li>
-        <li><%= link_to "マイページ", "#" %></li>
+        <li><%= link_to "マイページ", mypages_show_path %></li>
         <li>
           <%= link_to t('.logout'), destroy_user_session_path,
               data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" } %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,7 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.hosts << "award-snowsuit-despise.ngrok-free.dev"
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -39,5 +39,12 @@ ja:
       login: ログイン
       logout: ログアウト
       register: 新規登録
+  mypages:
+    show:
+      title: マイページ
+  line_connections:
+    show:
+      title: LINEアカウント連携
+  
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,8 @@ Rails.application.routes.draw do
   resources :mistakes, only: [ :index, :show, :new, :create, :destroy ]
   resource :user, only: [ :show, :edit, :update, :destroy ]
   resources :journal_corrections, only: [ :index, :show ]
-  resource :mypage, only: [:show]
-  resource :line_connection, only: [:show, :create, :destroy]
+  resource :mypage, only: [ :show ]
+  resource :line_connection, only: [ :show, :create, :destroy ]
 
 
   # テスト用ルーティング　あとで削除する
@@ -43,11 +43,11 @@ Rails.application.routes.draw do
 
   # LINE Messaging API(Webhook受信口)
   post "line/webhook", to: "line_webhooks#create"
-  
+
   # LINE連携開始
-  get "/line_login", to:"line_logins#new", as: :line_login
+  get "/line_login", to: "line_logins#new", as: :line_login
   # LINE認証・許可後に戻ってくるURL
-  get "/line_login/callback", to:"line_logins#callback"
+  get "/line_login/callback", to: "line_logins#callback"
   # Defines the root path route ("/")
   # root "posts#index"
   # 開発環境のみメール確認ツール

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "line_connections/show"
+  get "mypages/show"
   get "home/index"
   devise_for :users
   # これで以下のようなルーティングが自動生成される
@@ -25,6 +27,9 @@ Rails.application.routes.draw do
   resources :mistakes, only: [ :index, :show, :new, :create, :destroy ]
   resource :user, only: [ :show, :edit, :update, :destroy ]
   resources :journal_corrections, only: [ :index, :show ]
+  resource :mypage, only: [:show]
+  resource :line_connection, only: [:show, :create, :destroy]
+
 
   # テスト用ルーティング　あとで削除する
   # get '/test500', to: 'application#test500'
@@ -36,9 +41,13 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # LINE Messaging API
+  # LINE Messaging API(Webhook受信口)
   post "line/webhook", to: "line_webhooks#create"
-
+  
+  # LINE連携開始
+  get "/line_login", to:"line_logins#new", as: :line_login
+  # LINE認証・許可後に戻ってくるURL
+  get "/line_login/callback", to:"line_logins#callback"
   # Defines the root path route ("/")
   # root "posts#index"
   # 開発環境のみメール確認ツール

--- a/db/migrate/20260519121307_add_line_fields_to_users.rb
+++ b/db/migrate/20260519121307_add_line_fields_to_users.rb
@@ -1,0 +1,7 @@
+class AddLineFieldsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :line_user_id, :string
+    add_column :users, :line_notifications_enabled, :boolean, default: false
+    add_column :users, :line_link_code, :string
+  end
+end

--- a/db/migrate/20260521095439_add_line_friend_to_users.rb
+++ b/db/migrate/20260521095439_add_line_friend_to_users.rb
@@ -1,0 +1,5 @@
+class AddLineFriendToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :line_friend, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_01_151332) do
+ActiveRecord::Schema[7.2].define(version: 2026_05_21_095439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,6 +77,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_01_151332) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "avatar"
+    t.string "line_user_id"
+    t.boolean "line_notifications_enabled", default: false
+    t.string "line_link_code"
+    t.boolean "line_friend", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/line_connections_controller_test.rb
+++ b/test/controllers/line_connections_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class LineConnectionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get line_connections_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/line_connections_controller_test.rb
+++ b/test/controllers/line_connections_controller_test.rb
@@ -1,8 +1,15 @@
 require "test_helper"
 
 class LineConnectionsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+  end
+
   test "should get show" do
-    get line_connections_show_url
+    get line_connection_url
     assert_response :success
   end
 end

--- a/test/controllers/line_logins_controller_test.rb
+++ b/test/controllers/line_logins_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class LineLoginsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/line_webhooks_controller_test.rb
+++ b/test/controllers/line_webhooks_controller_test.rb
@@ -2,7 +2,19 @@ require "test_helper"
 
 class LineWebhooksControllerTest < ActionDispatch::IntegrationTest
   test "should receive webhook" do
-    post line_webhook_url
+    parser = Minitest::Mock.new
+    parser.expect(:parse, [], body: "{}", signature: "dummy_signature")
+
+    Line::Bot::V2::WebhookParser.stub(:new, parser) do
+    post line_webhook_url,
+         params: "{}",
+         headers: {
+          "CONTENT_TYPE" => "application/json",
+          "X-Line-Signature" => "dummy_signature"
+         }
     assert_response :success
   end
+
+  parser.verify
+end
 end

--- a/test/controllers/mypages_controller_test.rb
+++ b/test/controllers/mypages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MypagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get show" do
+    get mypages_show_url
+    assert_response :success
+  end
+end

--- a/test/controllers/mypages_controller_test.rb
+++ b/test/controllers/mypages_controller_test.rb
@@ -1,8 +1,15 @@
 require "test_helper"
 
 class MypagesControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+  end
+
   test "should get show" do
-    get mypages_show_url
+    get mypage_url
     assert_response :success
   end
 end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
  LINE Loginを利用して、アプリのユーザーとLINEアカウントを連携できるようにしました。
  連携後はLINEユーザーID、友だち追加状態、通知設定をUserに保存します。

  また、マイページからLINE連携画面へ遷移できる導線を追加しました。

## 変更内容
  - LINE連携用のカラムをusersテーブルに追加
    - `line_user_id`
    - `line_notifications_enabled`
    - `line_link_code`
    - `line_friend`
  - LINE Login用のルーティングを追加
    - `/line_login`
    - `/line_login/callback`

  - `LineLoginsController` を追加
    - LINE Login認可URLへのリダイレクト
    - callbackでのstate検証
    - 認可コードからアクセストークン / IDトークンを取得
    - IDトークン検証によるLINEユーザーID取得
    - 友だち追加状態の確認
    - ログイン中ユーザーへのLINE情報保存

  - LINE連携画面を追加
    - LINEアカウント連携ボタン
   
 - マイページを追加
    - プロフィール表示
    - LINE連携ページへの導線

  - ヘッダーのマイページリンクを実ページに接続

## 確認方法
  - [ ] マイページへ遷移できること
  - [ ] マイページからLINE連携画面へ遷移できること
  - [ ] 「LINEアカウントを連携する」押下でLINE Login画面へ遷移すること
  - [ ] LINE Login後、`line_user_id` がUserに保存されること
  - [ ] 友だち追加状態に応じて `line_friend` / `line_notifications_enabled` が保存されること
  - [ ] LINE連携済みの場合、連携済み表示が出ること

## 注意点
  - LINE LoginチャネルがDevelopingの場合、テストするLINEアカウントをTesterとして追加する必要があります。
  - 公式LINEをブロック / 解除してもRailsのDBは自動更新されないため、状態を更新するには再度LINE連携確認を行う必要がありま
  す。

## 関連Issue
closes #126 