### PR TITLE
fix:カレンダーのスマホ表示を調整

### DIFF
--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -25,7 +25,7 @@
     </div>
 
     <!-- カレンダー本体 -->
-    <div class="mt-1 grid grid-cols-7 gap-2 ">
+    <div class="mt-1 grid grid-cols-7 gap-2">
       <% day = @calendar_start %>
       <% while day <= @calendar_end %>
         <% journals = @journals_by_date[day] || [] %>
@@ -33,7 +33,7 @@
         <!-- 日記が1件の場合 -->
         <% if journals.size == 1 %>
           <%= link_to journal_path(journals.first), 
-              class:"group block min-h-28 rounded  bg-forest-500/80 px-3 py-3 rounded text-left hover:bg-gray-200" do %>
+              class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded  bg-forest-500/80 px-1 py-1 sm:py-2 sm:px-2 md:px-3 md:py-3 rounded text-left hover:bg-gray-200" do %>
           <div class="font-semibold text-white group-hover:text-forest-400" >
           <%= day.day %>
           <span class="text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
@@ -43,7 +43,7 @@
         <!-- 日記が2件以上の場合-->
         <% elsif journals.size > 1 %>
           <%= link_to journals_path(posted_date: day), 
-              class:"group block min-h-28 rounded  bg-forest-500/80 px-3 py-3  text-left hover:bg-gray-200" do %>
+              class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded bg-forest-500/80 px-1 py-1 sm:py-2 sm:px-2 md:px-3 md:py-3 text-left hover:bg-gray-200" do %>
             <div class="font-semibold text-white group-hover:text-forest-400">
             <%= day.day %>
             <span class="text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
@@ -53,7 +53,7 @@
 
           <!-- 日記がない日 -->
           <%= link_to new_journal_path(posted_date: day), 
-              class:"group block min-h-28 rounded  bg-gray-100 px-3 py-3  text-left text-forest-400 hover:bg-gray-200" do %>
+              class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded bg-gray-100 px-1 py-1 sm:px-2 sm:py-2 md:px-3 md:py-3 text-left text-forest-400 hover:bg-gray-200" do %>
             <div class="font-semibold group-hover:text-forest-400">
             <%= day.day %>
             </div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
カレンダー画面のスマホ表示を調整しました。

## 変更内容
  - カレンダーの日付セルの高さを画面幅ごとに調整

## 確認方法
- [ ]  スマホ幅でカレンダーのセル表示が崩れないこと

## 関連Issue
closes #