### PR TITLE
fix:LINEアカウント連携画面を調整

### DIFF
--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -36,7 +36,7 @@
               class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded bg-primary/80 px-1 py-1 sm:py-2 sm:px-2 md:px-3 md:py-3 rounded text-left hover:bg-primary" do %>
           <div class="font-semibold hover:bg-primary group-hover:text-primary-content" >
           <%= day.day %>
-          <span class="text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
+          <span class="block sm:inline text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
           </div>
           <% end %>
 
@@ -46,7 +46,7 @@
               class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded bg-primary/80 px-1 py-1 sm:py-2 sm:px-2 md:px-3 md:py-3 text-left hover:bg-primary" do %>
             <div class="font-semibold  group-hover:text-primary-content hover:bg-primary">
             <%= day.day %>
-            <span class="text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
+            <span class="block sm:inline text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
             </div>
           <% end %>
         <% else %>

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -1,12 +1,12 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+  <div class="max-w-6xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-4xl text-center mb-6">
       <%= t('.title') %>
     </h1>
 
-  <p class="mb-6 text-base-content text-center">
-    LINEアカウントを連携すると、週ごとの振り返りレポートや学習のヒントをLINEで受け取れます。
+  <p class="mb-6 text-base-content text-center sm:text-lg md:text-2xl">
+    LINEアカウントを連携すると、週ごとの振り返りレポートをお届けします。
   </p>
 
     <div class="card bg-base-100 shadow mb-6 p-5">
@@ -19,11 +19,11 @@
       <% else %>
         <%= link_to "LINEアカウントを連携する",
                   line_login_path,
-                  class: "btn w-full bg-[#06C755] text-white border-[#06C755] mb-5" %>
-        <p class="text-sm text-base-content">
+                  class: "btn w-full bg-[#06C755] text-white border-[#06C755]" %>
+        <!-- <p class="text-sm text-base-content">
         LINEアカウント連携完了しています。<br>LINE通知を受け取るには、公式LINEを友だち追加し、ブロックしている場合は解除してください。
         </p>
-          <%= link_to "もう一度LINE連携を確認する", line_login_path, class: "btn w-full bg-[#06C755] text-white" %>
+          <%# link_to "もう一度LINE連携を確認する", line_login_path, class: "btn w-full bg-[#06C755] text-white" %> -->
       <% end %>
 </div>
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
LINEアカウント連携のUI調整と、
本番環境でLINEログインのコールバックが動作するように、LINE Developers / Render 側のCallback URL設定を確認・追加しました。

## 変更内容
- LINEアカウント連携画面のUIを調整
- 本番環境のCallbackURLをLINE Developersに追加
- Renderの環境変数 `LINE_LOGIN_CALLBACK_URL` に本番用Callback URLを設定

## 確認方法

- [ ]  LINEアカウント連携画面が表示されること
- [ ]  「LINEアカウントを連携する」ボタンからLINEログイン画面へ遷移すること
- [ ]  本番環境のCallback URLがLINE Developersに登録されていること
- [ ]  `routes.rb` に `/line_login/callback` のルートが定義されていること

## 関連Issue
closes #