### PR TITLE
fix:ダークモード時の配色を調整

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -33,7 +33,7 @@ class JournalsController < ApplicationController
         if @journal.errors[:tone].present?
           "添削トーンを選択してください"
         else
-          "ジャーナルの作成に失敗しました。入力内容を確認してください"
+          "日記の作成に失敗しました。入力内容を確認してください"
         end
       render :new, status: :unprocessable_entity
       return
@@ -114,7 +114,7 @@ class JournalsController < ApplicationController
         redirect_to @journal, notice: "添削が完了しました！"
       else
         # DB保存に失敗したとき
-        flash.now[:alert] = "ジャーナルの作成に失敗しました。"
+        flash.now[:alert] = "日記の作成に失敗しました。"
         render :new, status: :unprocessable_entity
       end
       # AI添削処理の途中で例外が起きたとき(OpenAI/AI/API/予期しない処理エラー)
@@ -132,9 +132,9 @@ class JournalsController < ApplicationController
   def update
     @journal = current_user.journals.find(params[:id])
     if @journal.update(journal_params)
-      redirect_to journal_path(@journal), success: "ジャーナルが更新されました。"
+      redirect_to journal_path(@journal), success: "日記が更新されました。"
     else
-      flash.now[:alert] = "ジャーナルの更新に失敗しました。"
+      flash.now[:alert] = "日記の更新に失敗しました。"
       render :edit, status: :unprocessable_entity
     end
   end
@@ -142,7 +142,7 @@ class JournalsController < ApplicationController
   def destroy
     @journal = current_user.journals.find(params[:id])
     @journal.destroy
-    redirect_to journals_path, success: "ジャーナルが削除されました。", status: :see_other
+    redirect_to journals_path, success: "日記が削除されました。", status: :see_other
   end
 
   def calendar

--- a/app/views/devise/shared/_auth_wrapper.html.erb
+++ b/app/views/devise/shared/_auth_wrapper.html.erb
@@ -13,7 +13,7 @@
       <!--<p class="text-base sm:text-lg md:text-xl text-base-content-muted mt-4"> Write your thoughts. Track your growth. </p>-->
       <p class="text-base sm:text-lg md:text-xl text-base-content-muted mt-4"> Express your thoughts. Expand your world. </p>
     </div>
-    <div class="bg-base-100 border border-sage-100 rounded-3xl p-10 shadow-sm">
+    <div class="bg-base-100 border border-base-300 rounded-3xl p-10 shadow-sm">
     <!-- <div class="bg-washi rounded-3xl border border-washi-border shadow-md p-8"> -->
       <%= yield %>
     <!-- </div> -->

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -45,7 +45,7 @@
              <%= link_to journal_path(journal) do %>
             <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-3">
             
-            <p class="font-medium mb-2 items-center text-cream-500 text-base sm:text-lg flex gap-2">
+            <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-lg flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
               <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md  rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
@@ -54,7 +54,7 @@
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           
-            <!-- <%# link_to journal_path(journal), class: "btn btn-sm border border-forest-500 text-primary hover:bg-primary hover:bg-primary hover:opacity-80 hover:text-white text-base md:text-lg" do %>
+            <!-- <%# link_to journal_path(journal), class: "btn btn-sm border border-primary text-primary hover:bg-primary hover:bg-primary hover:opacity-80 hover:text-white text-base md:text-lg" do %>
             この日記を見る
             <%# end %> -->
             <% end %>

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -13,7 +13,7 @@
           <%= link_to journal_correction_path(journal_correction),
             class:"block border border-base-300 bg-base-100 rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           <%# 日付 %>
-            <div class="font-bold text-cream-500 flex items-center gap-3 mb-2">
+            <div class="font-bold text-base-content/70 flex items-center gap-3 mb-2">
               <span>
                 <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
               </span>

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -12,11 +12,11 @@
         <%= @journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>
       </div>
       <div class="flex gap-2 mb-2"><% if @previous_journal_correction.present? %>
-        <%= link_to "← 前の学び", @previous_journal_correction, class:"btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white" %>
+        <%= link_to "← 前の学び", @previous_journal_correction, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
       <% end %>
 
       <% if @next_journal_correction.present? %>
-        <%= link_to "次の学び →", @next_journal_correction, class:"btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white" %>
+        <%= link_to "次の学び →", @next_journal_correction, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
       <% end %>
       </div>
     </div>
@@ -67,11 +67,11 @@
         <%# 内側の白部分 %>
            <div class="mb-2">
               <% @journal_correction.mistakes.each do |mistake| %>
-              <div class="border border-forest-500 bg-base-100 rounded-2xl overflow-hidden mb-3">
+              <div class="border border-primary bg-base-100 rounded-2xl overflow-hidden mb-3">
                 
                 <%# 学んだ表現 %>
                 <div class="bg-secondary p-3 mb-1">
-                  <p class="text-lg md:text-2xl font-bold text-forest-700">
+                  <p class="text-lg md:text-2xl font-bold text-primary">
                     <%= mistake.learning_points["pattern"] %>
                   </p>
                   <p class="text-primary">
@@ -87,7 +87,7 @@
                 <div class="mx-3 bg-secondary rounded-xl px-2 py-2">
                   <p class=" text-primary font-semibold text-base md:text-lg">添削後：<%= mistake.corrected_text %></p> 
                 </div>
-                <hr class="border-forest-500 mb-2 mt-2">
+                <hr class="border-primary mb-2 mt-2">
 
               <%# ほかの表現・言い回し %>
               <p class="mx-3 text-base-content mb-2 text-base md:text-lg">似た表現・言い回し</p>
@@ -101,7 +101,7 @@
               <% end %>
                 <%= link_to "この日記を見る", 
                     @journal_correction.journal,
-                    class:"text-base md:text-lg mx-3 flex items-center justify-center btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white mb-2" %>                     
+                    class:"text-base md:text-lg mx-3 flex items-center justify-center btn btn-sm border-primary text-primary hover:bg-primary hover:text-white mb-2" %>                     
                 </div>
             <% end %>  
           </div>
@@ -110,11 +110,11 @@
     <% end %> 
     <div class="flex justify-end gap-2 mb-1">
       <% if @previous_journal_correction.present? %>
-        <%= link_to "← 前の学び", @previous_journal_correction, class:"btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white" %>
+        <%= link_to "← 前の学び", @previous_journal_correction, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
       <% end %>
 
       <% if @next_journal_correction.present? %>
-        <%= link_to "次の学び →", @next_journal_correction, class:"btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white" %>
+        <%= link_to "次の学び →", @next_journal_correction, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
       <% end %>
   
     </div>

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -81,8 +81,8 @@
 
                 <%# 添削前・添削後の文章 %>
                 <div class="mx-3 text-base-content mb-2 text-base md:text-lg">今回の添削</div>
-                  <div class="mx-3 bg-red-50 rounded-xl px-2 py-2 mb-2">
-                    <p class=" text-red-500 text-base md:text-lg">添削前：<%= mistake.original_text %></p>
+                  <div class="mx-3 bg-error/10 rounded-xl px-2 py-2 mb-2">
+                    <p class=" text-error text-base md:text-lg">添削前：<%= mistake.original_text %></p>
                 </div>
                 <div class="mx-3 bg-secondary rounded-xl px-2 py-2">
                   <p class=" text-primary font-semibold text-base md:text-lg">添削後：<%= mistake.corrected_text %></p> 
@@ -93,7 +93,7 @@
               <p class="mx-3 text-base-content mb-2 text-base md:text-lg">似た表現・言い回し</p>
 
               <% Array(mistake.learning_points["related_phrases"]).compact.each do |phrase| %>
-                <div class="mx-3 bg-base-100 border border-gray-300 rounded-2xl p-3 mb-2">
+                <div class="mx-3 bg-base-100 border border-base-300 rounded-2xl p-3 mb-2">
                   <p class="text-lg font-bold"><%= phrase["phrase"] %></p>
                   <p class="text-base md:text-lg"><%= phrase["meaning"] %></p>
                   <p class=" text-primary font-semibold text-base md:text-lg"><%= phrase["example"] %></p>

--- a/app/views/journals/_form.html.erb
+++ b/app/views/journals/_form.html.erb
@@ -2,7 +2,7 @@
   <%# render 'shared/error_messages', object: f.object %>
   <div class="mb-3">
     <p class="text-sans text-base md:text-lg font-medium mb-2">今日の気分</p>
-    <div class="border border-gray-300 bg-base-100 rounded-2xl py-3 px-3">
+    <div class="border border-base-300 bg-base-100 rounded-2xl py-3 px-3">
     <div class="flex gap-2">
     <% Journal.moods.each do |key, value| %>
       <label for="mood_<%= key %>" class="flex flex-col items-center cursor-pointer gap-1 flex-1">
@@ -28,7 +28,7 @@
 
     <button type="button"
             popovertarget="cally-popover1"
-            class="input input-bordered w-full text-left bg-base-100 rounded-2xl border-gray-300"
+            class="input input-bordered w-full text-left bg-base-100 rounded-2xl border-base-300"
             id="cally-trigger"
             style="anchor-name:--cally1">
       <span id="cally-text"><%= (@journal.posted_date || Date.current).strftime("%Y/%m/%d") %></span>
@@ -62,10 +62,6 @@
     </calendar-date>
   </div>
 
-  <!--<div class="mb-3">
-    <%= f.label :title, class: "label label-text text-base" %>
-    <%= f.text_field :title, class:"input input-bordered w-full" %>
-  </div> -->
   <div class="mb-3 md:text-lg">
     <%= f.label :body, class:"label label-text text-base font-medium" %>
     <%= f.text_area :body, class: "textarea textarea-bordered w-full text-base md:text-lg", rows: "10", 
@@ -95,8 +91,6 @@
         カジュアル
         </span>
       </label>
-      <%# f.submit "スタンダード", name:"tone",value: "standard", class:"btn btn-outline btn-primary flex-1" %>
-      <%# f.submit "カジュアル", name:"tone",value: "casual", class:"btn btn-outline btn-primary flex-1" %>
     </div>
   </div>
   <%= f.submit "添削する",

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -9,9 +9,9 @@
         <span class="text-primary text-sm sm:text-base md:text-2xl">(<%= @year %>年 <%= @month %>月)</span>
       </h1>
       <div class="flex items-center gap-2 flex-wrap text-xs sm:text-sm">
-        <%= link_to "前月", calendar_journals_path(year: @prev_year, month: @prev_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-forest-100 text-primary font-semibold hover:bg-forest-200" %>
-        <%= link_to "今月", calendar_journals_path(year: @today.year, month: @today.month), class:"px-4 py-2 rounded-xl border border-forest-500 bg-primary text-white font-semibold hover:bg-forest-600" %>
-        <%= link_to "翌月", calendar_journals_path(year:@next_year, month:@next_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-forest-100 text-primary font-semibold hover:bg-forest-200" %>
+        <%= link_to "前月", calendar_journals_path(year: @prev_year, month: @prev_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-secondary text-primary font-semibold hover:bg-forest-200" %>
+        <%= link_to "今月", calendar_journals_path(year: @today.year, month: @today.month), class:"px-4 py-2 rounded-xl border border-primary bg-primary text-white font-semibold hover:bg-forest-600" %>
+        <%= link_to "翌月", calendar_journals_path(year:@next_year, month:@next_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-secondary text-primary font-semibold hover:bg-forest-200" %>
       </div>
     </div>
 

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -1,11 +1,11 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-5xl mx-auto w-full pt-2 pb-6 sm:pt-6 md:px-2">
-    <div class="w-full bg-white/80 p-4 sm:p-6 rounded-3xl">
+    <div class="w-full bg-base-100/80 p-4 sm:p-6 rounded-3xl">
     
     <div class="flex items-center justify-between flex-wrap">
       <h1 class="text-lg sm:text-cl md:text-2xl font-semibold text-primary">
-        ジャーナルカレンダー
+        カレンダー
         <span class="text-primary text-sm sm:text-base md:text-2xl">(<%= @year %>年 <%= @month %>月)</span>
       </h1>
       <div class="flex items-center gap-2 flex-wrap text-xs sm:text-sm">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -3,7 +3,7 @@
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-bold font-sans text-lg md:text-4xl sm:text-2xl text-center font-cream-500 mb-6">
-    ジャーナル一覧
+    日記一覧
     </h1>
 
       <!-- <div class="actions mb-4">
@@ -17,7 +17,7 @@
             <%= button_to "削除",
                 journal_path(journal),
                 method: :delete,
-                form: {data: {turbo_confirm:"このジャーナルを削除しますか？"}},
+                form: {data: {turbo_confirm:"この日記を削除しますか？"}},
                 class: "btn btn-sm text-sm text-center hover:opacity-70"
             %>
           </div>-->
@@ -35,7 +35,7 @@
               <%= button_to "削除",
                   journal_path(journal),
                   method: :delete,
-                  form: {data: {turbo_confirm:"このジャーナルを削除しますか？"}},
+                  form: {data: {turbo_confirm:"この日記を削除しますか？"}},
                   class: "btn btn-sm text-sm text-center bg-base-300 hover:opacity-70"
               %>
             </span>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -25,7 +25,7 @@
           <div class="border border-base-300 bg-base-100 rounded-lg py-3 mb-2 px-4">
 
             <div class="flex items-center gap-3">
-              <span class="font-bold text-cream-500 mb-2">
+              <span class="font-bold text-base-content/70 mb-2">
                 <%= journal.posted_date.strftime("%Y/%m/%d") %>
               </span>
               <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md rounded-full px-2 py-1">

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -8,11 +8,11 @@
 
   <div class="flex justify-between">
   <% if @previous_journal.present? %>
-    <%= link_to "前の日記", @previous_journal, class:"btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white" %>
+    <%= link_to "前の日記", @previous_journal, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
   <% end %>
 
   <% if @next_journal.present? %>
-    <%= link_to "次の日記", @next_journal, class:"btn btn-sm border-forest-500 text-primary hover:bg-primary hover:text-white" %>
+    <%= link_to "次の日記", @next_journal, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
   <% end %>
   </div>
   <%# 元の文章（日本語でもそのまま表示） %>
@@ -22,7 +22,7 @@
     </div>
       <div class="md:hidden collapse collapse-arrow border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">
         <input type="checkbox" />
-          <h2 class="collapse-title font-semibold pr-10 bg-red-50 text-red-500">元の文章を表示</h2>
+          <h2 class="collapse-title font-semibold pr-10 bg-error/10 text-error">元の文章を表示</h2>
 
           <div class="collapse-content">
             <p class="px-2 py-2 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
@@ -31,8 +31,8 @@
 
        <%# 枠開始 %>
       <div class="hidden md:block border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">
-        <div class="bg-red-50 border-b border-red-100 px-4">
-          <h2 class="font-semibold text-base md:text-lg text-red-500 py-2">元の文章 </h2>
+        <div class="bg-error/10 border-b border-red-100 px-4">
+          <h2 class="font-semibold text-base md:text-lg text-error py-2">元の文章 </h2>
         </div>  
         <p class="text-base md:text-lg px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
     </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -1,7 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-  <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <%# ページタイトル %>
     <h1 class="font-sans font-semibold text-lg md:text-4xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
@@ -30,7 +29,6 @@
           </div>
       </div>
 
-  <%# md以上：通常表示 %>
        <%# 枠開始 %>
       <div class="hidden md:block border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">
         <div class="bg-red-50 border-b border-red-100 px-4">
@@ -43,89 +41,10 @@
       <%= render "shared/mistakes_list", mistakes: @mistakes, show_original_text: true, journal: @journal %>
     <% end %>
 
-    <%# 添削後の英文(全文) %>
-    <!--<div class="border border-base-300 bg-forest-100 rounded-2xl p-4 mb-4">
-      <div class="flex items-center gap-2">
-        <h2 class="font-semibold mb-3">添削後の文章</h2>
-        <span class="badge badge-soft badge-success text-white mb-3 p-3">
-        添削トーン：<%= t("activerecord.attributes.journal.tones.#{@journal.tone}") %></span>
-      </div>
-        <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-2">
-          <p>  
-          <%= @journal_correction&.rewritten_text %>
-          </p>
-        </div>
-    </div>
-
-    <%# 個別の指摘リストを表示 %>
-    <% if @mistakes.present? %>
-      <div class="border border-base-300 bg-forest-100 rounded-2xl p-4 mb-4">
-          <h2 class="font-semibold mb-3">今回の学び（<%= @mistakes.size %>件）</h2>
-
-          <div class="border border-gray-300 bg-base-100 rounded-2xl p-4 mb-2">
-            <ol class="list-decimal list-inside">
-            <% @mistakes.each do |mistake| %>
-              <li class="mb-4">
-              <span class="font-semibold">
-              <%= mistake_type_label(mistake.mistake_type) %></span>
-              <p class="text-base font-normal">  【元の文章】: <%= mistake.original_text %></p>
-              <p class="text-base font-normal">  【添削後】: <%= mistake.corrected_text %></p>
-              <p class="text-sm text-base-content font-normal">  ポイント: <%= mistake.explanation %></p>
-
-              </li>
-          <% end %>
-            </ol>
-          </div>
-      </div>
-    <% else %>
-      <div class="alert alert-success mb-4">
-        <span>🎉 間違いは見つかりませんでした！</span>
-      </div>
-    <% end %>
-
-    <%# strengths に データがある場合のみ「英文の傾向」ブロックを表示 %>
-    <% if @journal_correction&.strengths.present? %>
-
-      <%# 外側のカード %>
-      <div class="border border-base-300 bg-forest-100 rounded-2xl p-4 mb-4">
-        <h3 class="font-semibold text-base mb-2">英文の傾向</h3>
-        
-  
-        <div class="border border-gray-300 bg-base-100 rounded-2xl p-4 mb-2">
-          <div class="mb-2">  
-            <p class="font-semibold">良い点</p>
-              <% (@journal_correction.strengths || []).each do |strength|  %>
-              <p>【強み】<%= strength["point"] %></p>
-              <p>【元の文章】<%= strength["evidence"] %></p>
-              <p>【何が良かったか】<%= strength["why_it_works"] %></p>
-              <% end %>
-          </div>
-
-            
-
-          <div class="mb-2">  
-            <p class="font-semibold">間違いパターン</p>
-            <% (@journal_correction.mistake_patterns || []).each do |pattern| %>
-              <div class="mb-2">
-              <p>【パターン】<%= pattern["point"] %></p>
-              <p>【元の文章】<%= pattern["evidence"] %></p>
-              <p>【説明】<%= pattern["explanation"] %></p>
-              </div>
-            <% end %>
-          </div>
-  
-
-          <p class="font-semibold">アドバイス</p>
-          <p><%= @journal_correction["advice"] %></p>
-        </div>
-      </div>
-    <% end %> -->
-     
-
     <div class="flex mt-5 gap-5">
-    <%= link_to 'ジャーナル一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base md:text-lg" %>
-    <%= button_to "このジャーナルを削除",
-        journal_path(@journal), method: :delete, form: { data: { turbo_confirm: "このジャーナルを削除しますか?"}}, class: "btn btn-error" %>
+    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base md:text-lg" %>
+    <%= button_to "この日記を削除",
+        journal_path(@journal), method: :delete, form: { data: { turbo_confirm: "この日記を削除しますか?"}}, class: "btn btn-error" %>
     </div>
 
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <%# ログイン後のヘッダー %>
-<header class="navbar bg-base-100 border-b border-sage-100 fixed top-0 left-0 right-0 z-50 px-4 h-16">
+<header class="navbar bg-base-100 border-b border-base-300 fixed top-0 left-0 right-0 z-50 px-4 h-16">
   <div class="navbar-start">
     <%= link_to "Capture Your Day", (user_signed_in? ? authenticated_root_path : unauthenticated_root_path), class:"font-title text-lg sm:text-xl md:text-2xl font-bold text-base-content leading-tight"%>
     <%# link_to "Home", root_path, class: "btn btn-ghost normal-case text-xl" %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
   <div class="flex items-center gap-1 flex-nowrap">
     <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
-    <%= link_to "ジャーナル一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
+    <%= link_to "日記一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-sm md:text-lg" %>
     <%= link_to "マイページ", mypage_path, class: "btn btn-ghost normal-case text-md md:text-lg" %>
@@ -92,7 +92,7 @@
       <% if user_signed_in? %>
         <li><%= link_to "ホーム", authenticated_root_path %></li>
         <li><%= link_to "日記を書く", new_journal_path %></li>
-        <li><%= link_to "ジャーナル一覧", journals_path %></li>
+        <li><%= link_to "日記一覧", journals_path %></li>
         <li><%= link_to "カレンダー", calendar_journals_path %></li>
         <li><%= link_to "表現一覧", journal_corrections_path %></li>
         <li><%= link_to "マイページ", mypages_show_path %></li>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -11,7 +11,7 @@
     <% if @journal_correction.mistakes.present? %>
       <div class="flex justify-between items-center mb-3">
         <h2 class="text-lg md:text-2xl font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
-          <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-forest-500  bg-secondary text-primary hover:bg-primary hover:text-white text-base md:text-lg" %>
+          <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-primary  bg-secondary text-primary hover:bg-primary hover:text-white text-base md:text-lg" %>
       </div>
 
           <% @journal_correction.mistakes.each do |mistake| %>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -35,16 +35,16 @@
                 
                 <%# ボディ %>
                 <div class="px-4 py-3">
-                  <p class="text-gray-600 mb-1 text-base md:text-lg">今回の添削</p>
-                  <p class="mx-2 text-base md:text-lg bg-red-50 px-3 py-2 text-red-500 mb-2 rounded-xl">  
+                  <p class="text-base-content/70 mb-1 text-base md:text-lg">今回の添削</p>
+                  <p class="mx-2 text-base md:text-lg bg-error/10 px-3 py-2 text-error mb-2 rounded-xl">  
                   <%= mistake.original_text %></p>
                   <p class="mx-2 text-base md:text-lg  bg-base-200  text-primary font-semibold border-forest-200 rounded-xl px-3 py-2">
                   <%= mistake.corrected_text %></p>
 
                 <%# ポイント %>
                 <% if mistake.explanation.present? %>
-                  <p class="text-gray-600 mt-2 text-base md:text-lg">ポイント</p>
-                  <div class="mx-2 bg-gray-50 rounded-xl px-3 py-2 text-base-content">
+                  <p class="text-base-content/70 mt-2 text-base md:text-lg">ポイント</p>
+                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content">
                     <%= mistake.explanation %>
                   </div>
                 <% end %>

--- a/app/views/top/_main.html.erb
+++ b/app/views/top/_main.html.erb
@@ -75,7 +75,7 @@ flex items-center justify-center py-16 px-5 md:px-10">
 <section class="py-16 px-10 bg-base-200 border border-base-300">
 
   <%# セクションラベル＆タイトル %>
-  <p class="text-2xl font-medium tracking-widest text-cream-500 text-center mb-2">FEATURES</p>
+  <p class="text-2xl font-medium tracking-widest text-base-content/70 text-center mb-2">FEATURES</p>
   <h2 class="font-sans text-2xl font-normal text-center text-base-content mb-5">
   Capture Your Dayの3つの特徴
   </h2>
@@ -87,8 +87,8 @@ flex items-center justify-center py-16 px-5 md:px-10">
     <div class="bg-base-100 border border-base-300 rounded-[20px] p-6 py-14 text-center">
     
       <div class="w-12 h-12 rounded-full bg-primary flex items-center justify-center mx-auto mb-4">
-        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none"
-             stroke="#1D9E75" stroke-width="1.8"
+        <svg class="w-5 h-5 stroke-current" viewBox="0 0 24 24" fill="none"
+            stroke-width="1.8"
              stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 20h9M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/>
         </svg>
@@ -104,8 +104,8 @@ flex items-center justify-center py-16 px-5 md:px-10">
     <div class="bg-base-100 border border-base-300 rounded-[20px] p-6 py-14 text-center">
       <div class="w-12 h-12 rounded-full bg-primary flex items-center
                   justify-center mx-auto mb-4">
-        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none"
-             stroke="#1D9E75" stroke-width="1.8"
+        <svg class="w-5 h-5 stroke-current" viewBox="0 0 24 24" fill="none"
+             stroke-width="1.8"
              stroke-linecap="round" stroke-linejoin="round">
           <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/>
         </svg>
@@ -121,8 +121,8 @@ flex items-center justify-center py-16 px-5 md:px-10">
     <div class="bg-base-100 border border-base-300 rounded-[20px] p-6  py-14 text-center">
       <div class="w-12 h-12 rounded-full bg-primary flex items-center
                   justify-center mx-auto mb-4">
-        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none"
-             stroke="#1D9E75" stroke-width="1.8"
+        <svg class="w-5 h-5 stroke-current" viewBox="0 0 24 24" fill="none"
+             stroke-width="1.8"
              stroke-linecap="round" stroke-linejoin="round">
           <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
         </svg>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -22,11 +22,11 @@ ja:
     new:
   journals:
     new:
-      title: ジャーナリング作成
+      title: 日記を作成
     show:
-      title: ジャーナル添削結果
+      title: 日記添削結果
     index:
-      title: ジャーナリング一覧
+      title: 日記一覧
     calendar:
       title: カレンダー
   journal_corrections:
@@ -44,7 +44,7 @@ ja:
       title: マイページ
   line_connections:
     show:
-      title: LINEアカウント連携
+      title: LINE通知設定
   views:
     pagination:
       first: "最初"

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -89,23 +89,23 @@ module.exports = {
           "error":            "#f87272",
         },
         // ダークモード
-          "color-dark": {
-          "primary":          "#5DCAA5",  
-          "primary-content":  "#1A3D2E",
-          "secondary":        "#2C5F45",  
-          "secondary-content":"#D6EDE3",
-          "accent":           "#7DB89E",
-          "accent-content":   "#1A3D2E",
-          "neutral":          "#D6EDE3",
-          "neutral-content":  "#2A3D34",
-          "base-100":         "#334D3F",   // カード背景（明るめに）
-          "base-200":         "#2A3D34",   // ページ背景
-          "base-300":         "#3D5C48",   // ボーダー
-          "base-content":     "#D6EDE3",
-          "info":             "#3abff8",
-          "success":          "#5DCAA5",
-          "warning":          "#fbbd23",
-          "error":            "#f87272",
+          "color-dark": { 
+            "primary":          "#34D399",
+            "primary-content":  "#052E2B",
+            "secondary":        "#1F2937",
+            "secondary-content":"#D1FAE5",
+            "accent":           "#6EE7B7",
+            "accent-content":   "#052E2B",
+            "neutral":          "#E5E7EB",
+            "neutral-content":   "#111827",
+            "base-100":          "#1F2937",     // カード背景
+            "base-200":          "#111827",     // ページ背景
+            "base-300":          "#374151",     // ボーダー
+            "base-content":      "#F9FAFB",
+            "info":             "#38BDF8",
+            "success":          "#34D399",
+            "warning":          "#FBBF24",
+            "error":            "#F87171",
         },
       },
     ],

--- a/test/controllers/journals_controller_test.rb
+++ b/test/controllers/journals_controller_test.rb
@@ -9,7 +9,7 @@ setup do
   @user = users(:one)
   # ② そのユーザーでログインする
   sign_in @user
-  # ③ テスト用のジャーナルをfixturesから取得する
+  # ③ テスト用の日記をfixturesから取得する
   @journal = journals(:one)
 end
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ダークモード時の配色を見直しし、視認性を改善しました。

## 変更内容
  - ダークモードの背景色・カード背景色を調整
  - 固定色をDaisyUIのテーマ色に変更

## 確認方法
  - [ ] ダークモードで各画面の背景とカードの境界が見やすい
  - [ ] 「今回の添削」「ポイント」の文字が読みやすい

## 関連Issue
closes #