### PR TITLE
fix:ページネーションの表示を調整

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -7,7 +7,7 @@ class JournalCorrectionsController < ApplicationController
                            .includes(:journal, :mistakes)
                            .joins(:journal)
                            .where(journals: { posted_date: Date.current.all_month })
-                           .order("journals.posted_date DESC, journal_corrections.journal_id DESC").page(params[:page]).per(20)
+                           .order("journals.posted_date DESC, journal_corrections.journal_id DESC").page(params[:page]).per(10)
   end
 
   def show

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -7,7 +7,7 @@ class JournalsController < ApplicationController
       if params[:posted_date].present?
         @journals = @journals.where(posted_date: params[:posted_date])
       end
-    @journals = @journals.order(posted_date: :desc, id: :desc).page(params[:page]).per(20)
+    @journals = @journals.order(posted_date: :desc, id: :desc).page(params[:page]).per(10)
   end
 
   def show

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Kaminari.configure do |config|
-  config.default_per_page = 20
+  config.default_per_page = 10
   # config.max_per_page = nil
   config.window = 2
   # config.outer_window = 0


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
日記一覧と表現一覧の表示件数を調整しました。

## 変更内容
- ページネーションの表示件数を20件から10件に変更

## 関連Issue
closes #