### PR TITLE
feat:ログイン後のホーム画面にLINE通知設定カードを追加

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,29 +8,43 @@
 
     <div class="flex justify-center gap-2 mb-4">
       <div class=" bg-secondary rounded-2xl p-3 text-center flex-1">
-        <p class="text-2xl font-semibold text-primary"><%= @total_count %><span class="text-xs sm:text-lg font-medium"> 件</span></p>
-        <p class="text-sm text-base-content-muted">総投稿数</p>
+        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @total_count %><span class="text-xs sm:text-lg font-medium"> 件</span></p>
+        <p class="text-sm sm:text-md md:text-lg text-base-content-muted ">総投稿数</p>
       </div>
       <div class="bg-secondary rounded-2xl p-3 text-center flex-1">
-        <p class="text-2xl font-semibold text-primary"><%= @total_learning_count %><span class="text-xs sm:text-lg font-medium"> フレーズ</span></p>
-        <p class="text-sm text-base-content-muted">学んだ表現</p>
+        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @total_learning_count %><span class="text-xs sm:text-lg font-medium"> フレーズ</span></p>
+        <p class="text-sm text-base-content-muted sm:text-md md:text-lg">学んだ表現</p>
       </div>
       <div class="bg-secondary rounded-2xl p-3 text-center flex-1">
-        <p class="text-2xl font-semibold text-primary"><%= @streak_count %><span class="text-xs sm:text-lg font-medium"> 日</span></p>
-        <p class="text-sm text-base-content-muted">連続投稿日数</p>
+        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @streak_count %><span class="text-xs sm:text-lg font-medium"> 日</span></p>
+        <p class="text-sm sm:text-md md:text-lg text-base-content-muted">連続投稿日数</p>
       </div>
     </div>
-
+    <div>
+     <% if current_user.line_user_id.blank? %>
+       <%= link_to line_connection_path,
+           class: "block card bg-base-100 border border-primary mb-4 p-2 px-4 hover:bg-base-200 transition" do %>
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <p class="font-bold text-primary text-base sm:text-md md:text-lg">
+          LINEで、学んだフレーズを週1回お届け
+        </p>
+        <span class="btn bg-[#06C755] border-[#06C755] text-white sm:w-52 w-full pointer-events-none text-sm sm:text-md md:text-lg">
+          LINE通知設定へ
+        </span>
+        </div>
+        <% end %>
+     <% end %>
+    </div>
     <div class="bg-secondary rounded-2xl p-5 mb-4">
       <%# 今日の気持ちを英語にしてみよう %>
-      <p class="font-bold font-sans text-base text-center text-success sm:text-lg md:text-xl mb-1">
+      <p class="font-bold font-sans text-base text-center text-success sm:text-lg md:text-2xl mb-1">
         今日、心が動いたことは？
       </p>
-      <p class="text-center sm:text-base md:text-lg text-primary mb-2">
+      <p class="text-center text-base sm:text-lg md:text-xl text-primary mb-2">
         日本語でも英語でも、気持ちを書き残してみよう
       </p>
       <div class="flex justify-center">
-        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base md:text-lg" %>
+        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base sm:text-lg md:text-xl" %>
       </div>
     </div>
   
@@ -47,10 +61,10 @@
             
             <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-lg flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
-              <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md  rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
+              <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
     
-            <p class="text-base-content mb-3 line-clamp-2 text-base md:text-lg">
+            <p class="text-base-content mb-3 line-clamp-2 text-base sm:text-lg md:text-xl">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -13,7 +13,7 @@
           <%= link_to journal_correction_path(journal_correction),
             class:"block border border-base-300 bg-base-100 rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           <%# 日付 %>
-            <div class="font-bold text-base-content/70 flex items-center gap-3 mb-2">
+            <div class="font-bold text-base-content/70 flex items-center gap-3 mb-2 sm:text-lg">
               <span>
                 <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
               </span>
@@ -25,8 +25,8 @@
 
         <div class="mb-2">
           <% journal_correction.mistakes.first(2).each do |mistake| %>
-            <p class="font-semibold text-base md:text-lg"><%= mistake.learning_points["pattern"] %></p>
-            <p class="text-base-content">【意味】<%= mistake.learning_points["meaning"] %></p>
+            <p class="font-semibold text-base sm:text-lg md:text-xl"><%= mistake.learning_points["pattern"] %></p>
+            <p class="text-base-content sm:text-md md:text-lg">【意味】<%= mistake.learning_points["meaning"] %></p>
           
             <!--<% if mistake.learning_points["related_phrases"].present? %>
               <% mistake.learning_points["related_phrases"].each do |phrase| %> 

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <!-- 曜日 -->
-    <div class="mt-4 grid grid-cols-7 gap-2 text-center text-sm sm:text-base md:text-lg">
+    <div class="mt-4 grid grid-cols-7 gap-2 text-center text-sm sm:text-lg md:text-xl">
       <% [ "月", "火", "水", "木", "金", "土", "日"].each do |day| %>
         <div class="px-2 py-1 text-center font-medium text-primary">
           <%= day %>
@@ -25,7 +25,7 @@
     </div>
 
     <!-- カレンダー本体 -->
-    <div class="mt-1 grid grid-cols-7 gap-2">
+    <div class="mt-1 grid grid-cols-7 gap-2 text-base sm:text-lg md:text-xl">
       <% day = @calendar_start %>
       <% while day <= @calendar_end %>
         <% journals = @journals_by_date[day] || [] %>
@@ -36,7 +36,7 @@
               class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded bg-primary/80 px-1 py-1 sm:py-2 sm:px-2 md:px-3 md:py-3 rounded text-left hover:bg-primary" do %>
           <div class="font-semibold hover:bg-primary group-hover:text-primary-content" >
           <%= day.day %>
-          <span class="block sm:inline text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
+          <span class="block sm:inline text-sm sm:text-md md:text-lg">(<%= journals.size %>件)</span>
           </div>
           <% end %>
 
@@ -46,7 +46,7 @@
               class:"group block min-h-12 sm:min-h-20 md:min-h-32 rounded bg-primary/80 px-1 py-1 sm:py-2 sm:px-2 md:px-3 md:py-3 text-left hover:bg-primary" do %>
             <div class="font-semibold  group-hover:text-primary-content hover:bg-primary">
             <%= day.day %>
-            <span class="block sm:inline text-xs sm:text-sm md:text-md">(<%= journals.size %>件)</span>
+            <span class="block sm:inline text-sm sm:text-md md:text-lg">(<%= journals.size %>件)</span>
             </div>
           <% end %>
         <% else %>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -42,7 +42,7 @@
             </div>
             <%# 本文 %>
             <%= link_to journal_path(journal) do %>
-            <p class="text-base md:text-lg mb-3 line-clamp-2">
+            <p class="text-base sm:text-lg md:text-xl mb-3 line-clamp-2">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
             <% end %>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -34,7 +34,7 @@
         <div class="bg-error/10 border-b border-red-100 px-4">
           <h2 class="font-semibold text-base md:text-lg text-error py-2">元の文章 </h2>
         </div>  
-        <p class="text-base md:text-lg px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
+        <p class="text-base sm:text-lg md:text-xl px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
     </div>
   
     <% if @journal_correction.present? %>
@@ -42,7 +42,7 @@
     <% end %>
 
     <div class="flex mt-5 gap-5">
-    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base md:text-lg" %>
+    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base sm:text-lg md:text-xl" %>
     <%= button_to "この日記を削除",
         journal_path(@journal), method: :delete, form: { data: { turbo_confirm: "この日記を削除しますか?"}}, class: "btn btn-error" %>
     </div>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -5,7 +5,7 @@
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
-          <p class="text-base md:text-lg px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
+          <p class="text-base sm:text-lg md:text-xl px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
     </div>
 
     <% if @journal_correction.mistakes.present? %>
@@ -44,7 +44,7 @@
                 <%# ポイント %>
                 <% if mistake.explanation.present? %>
                   <p class="text-base-content/70 mt-2 text-base md:text-lg">ポイント</p>
-                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content">
+                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content sm:text-md md:text-lg">
                     <%= mistake.explanation %>
                   </div>
                 <% end %>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ログイン後のホーム画面に、LINE未連携ユーザー向けのLINE通知設定カードを追加しました。

## 変更内容
 - `current_user.line_user_id.blank?` の場合のみ、ホーム画面にLINE通知設定カードを表示
  - ホーム画面の投稿数・学習フレーズ数・連続投稿日数の文字サイズを調整
  - 日記一覧、カレンダー、添削結果表示まわりの文字サイズをレスポンシブに調整
  
## 確認方法
  - LINE未連携ユーザーでホーム画面にLINE通知設定カードが表示されること
  - LINE連携済みユーザーではカードが表示されないこと
  - カード全体をクリックするとLINE通知設定画面へ遷移すること

## 関連Issue
closes #187 