### PR TITLE
feat:週次LINEレビュー配信機能を追加

### DIFF
--- a/app/services/weekly_learning_analyzer.rb
+++ b/app/services/weekly_learning_analyzer.rb
@@ -1,3 +1,4 @@
+# 1週間分の学習候補からAIで最大3つ選ぶ
 class WeeklyLearningAnalyzer
   MAX_CANDIDATES = 50
   # 直近1週間の日記を対象に、ユーザーが学んだ表現を抽出するサービスクラス
@@ -7,19 +8,6 @@ class WeeklyLearningAnalyzer
     @to = to
   end
 
-  #   def call
-  #     mistakes.map do |mistake|
-  #       {
-  #         date: mistake.journal.posted_date,
-  #         original_text: mistake.original_text,
-  #         corrected_text: mistake.corrected_text,
-  #         explanation: mistake.explanation,
-  #         pattern: mistake.learning_points["pattern"],
-  #         meaning: mistake.learning_points["meaning"],
-  #         review_tag: mistake.learning_points["review_tag"],
-  #         related_phrases: mistake.learning_points["related_phrases"]
-  #       }
-  #     end
   def call
     candidates = learning_items.first(MAX_CANDIDATES)
     return { total_count: 0, items: [] } if candidates.blank?
@@ -111,30 +99,29 @@ class WeeklyLearningAnalyzer
       - コロケーション
 
       優先度を下げる候補:
-      - ただの便利フレーズ紹介になりやすいもの
       - original_text と corrected_text の違いが分かりにくいもの
       - 「自然な表現です」以上の説明がしにくいもの
       - その日記でしか使いにくい個人的すぎる内容
       - 長すぎる文
 
 
-    grammar_point の書き方:
-    - grammar_point は「次に自分で使うための文法・ニュアンスメモ」として書いてください
-    - 以下のうち、候補に合うものを1〜2文で説明してください
-        1. その表現の意味・ニュアンス
-        2. 形のルール
-        3. 同じルールで使える代表例を1〜3個
-    - original_text と corrected_text の違いが明確な場合は、どこをどう直したかも説明してください
-    - 「自然な表現です」「便利です」だけの説明は禁止です
+      grammar_point の書き方:
+      - grammar_point は「次に自分で使うための文法・ニュアンスメモ」として書いてください
+      - 以下のうち、候補に合うものを1〜2文で説明してください
+          1. その表現の意味・ニュアンス
+          2. 形のルール
+          3. 同じルールで使える代表例を1〜3個
+      - original_text と corrected_text の違いが明確な場合は、どこをどう直したかも説明してください
+      - 「自然な表現です」「便利です」だけの説明は禁止です
 
-    良い grammar_point の例:
-    - have been thinking about は、ある時点から今まで考え続けている状態を表します。about など前置詞の後ろに動詞を置くとき
-    は、going / studying のように動名詞にします。
-    - enjoy の後ろに動詞を置くときは、to do ではなく doing を使います。同じように動名詞が続きやすい動詞には finish /
-    avoid / consider などがあります。
-    - look forward to の to は前置詞なので、後ろは see ではなく seeing のように動名詞にします。同じ形で be used to + 動名
-    詞 も使えます。
-    - I wonder if は「〜かなと思う」とやわらかく言いたいときに使います。if の後ろには主語 + 動詞の文を続けます
+      良い grammar_point の例:
+      - have been thinking about は、ある時点から今まで考え続けている状態を表します。about など前置詞の後ろに動詞を置くとき
+      は、going / studying のように動名詞にします。
+      - enjoy の後ろに動詞を置くときは、to do ではなく doing を使います。同じように動名詞が続きやすい動詞には finish /
+      avoid / consider などがあります。
+      - look forward to の to は前置詞なので、後ろは see ではなく seeing のように動名詞にします。同じ形で be used to + 動名
+      詞 も使えます。
+      - I wonder if は「〜かなと思う」とやわらかく言いたいときに使います。if の後ろには主語 + 動詞の文を続けます
 
       悪い grammar_point:
       - 自然な表現です

--- a/app/services/weekly_review_broadcaster.rb
+++ b/app/services/weekly_review_broadcaster.rb
@@ -1,0 +1,45 @@
+# 週次LINE配信全体を管理するクラス
+class WeeklyReviewBroadcaster
+  def initialize(date: Date.current)
+    @date = date
+  end
+
+  def call
+    target_users.find_each do |user|
+      deliver_to(user)
+    end
+  end
+
+  private
+
+  attr_reader :date
+
+  def target_users
+    User.where.not(line_user_id: [nil, ""])
+  end
+
+  def deliver_to(user)
+    from = date.prev_week(:monday)
+    to = from + 6.days
+
+    result = WeeklyLearningAnalyzer.new(
+      user: user,
+      from: from,
+      to: to
+    ).call
+    
+    message = WeeklyReviewMessageBuilder.new(
+      user: user,
+      result: result
+    ).call
+
+    return if message.blank?
+
+    LineMessageSender.new(
+      user: user,
+      message: message
+    ).call
+  rescue => e
+    Rails.logger.error("[WeeklyReviewBroadcaster] user_id=#{user.id} #{e.class}: #{e.message}")
+  end
+end

--- a/app/services/weekly_review_broadcaster.rb
+++ b/app/services/weekly_review_broadcaster.rb
@@ -15,7 +15,7 @@ class WeeklyReviewBroadcaster
   attr_reader :date
 
   def target_users
-    User.where.not(line_user_id: [nil, ""])
+    User.where.not(line_user_id: [ nil, "" ])
   end
 
   def deliver_to(user)
@@ -27,7 +27,7 @@ class WeeklyReviewBroadcaster
       from: from,
       to: to
     ).call
-    
+
     message = WeeklyReviewMessageBuilder.new(
       user: user,
       result: result

--- a/app/services/weekly_review_message_builder.rb
+++ b/app/services/weekly_review_message_builder.rb
@@ -1,3 +1,5 @@
+
+# LINE用メッセージ本文を作る
 class WeeklyReviewMessageBuilder
   def initialize(user:, result:)
     @user = user
@@ -9,8 +11,8 @@ class WeeklyReviewMessageBuilder
     return nil if items.blank?
 
     lines = []
-    lines << "#{user.name}さん、今週もお疲れさまです。"
-    lines << "この1週間で学んだフレーズは#{total_count}個です。その中でも次も使いやすい表現をピックアップしました。"
+    lines << "#{user.name}さん、今週もお疲れさまです😊"
+    lines << "この1週間で学んだフレーズは#{total_count}個です🎉その中でも次も使いやすい表現をピックアップしました。"
     lines << ""
     lines << "【今週学んだ表現】"
 
@@ -21,8 +23,10 @@ class WeeklyReviewMessageBuilder
       lines << item[:corrected_text].to_s
       lines << "【ポイント】"
       lines << item[:grammar_point].to_s
-      lines << ""
     end
+      lines << ""
+      lines << "他の表現も復習する："
+      lines << "https://capture-your-day.onrender.com/journal_corrections"
 
   lines.join("\n").strip
   end

--- a/lib/tasks/weekly_reviews.rake
+++ b/lib/tasks/weekly_reviews.rake
@@ -3,7 +3,7 @@
 namespace :weekly_reviews do
   # タスクの説明文
   desc "Send weekly LINE review messages to users with LINE user ID"
-  
+
   # タスク名
   task send: :environment do
     WeeklyReviewBroadcaster.new.call

--- a/lib/tasks/weekly_reviews.rake
+++ b/lib/tasks/weekly_reviews.rake
@@ -1,0 +1,11 @@
+
+# namespace:Rake task の名前をグループ分け
+namespace :weekly_reviews do
+  # タスクの説明文
+  desc "Send weekly LINE review messages to users with LINE user ID"
+  
+  # タスク名
+  task send: :environment do
+    WeeklyReviewBroadcaster.new.call
+  end
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
週次LINEレビュー配信と学習分析結果のLINE通知を実装しました。
毎週月曜19:00にLINE連携済みユーザーに対して、先週分の学習内容をAIで分析してLINE送信できるようにしています。

## 変更内容
  - WeeklyReviewBroadcaster を追加
    - LINE IDがあるユーザーを取得
    - 先週月曜〜日曜の学習内容を対象にAI分析
    - LINE本文を生成
    - LINEメッセージを送信
    - ユーザー単位で例外を rescue し、1人の失敗で全体配信が止まらないように対応

  ## 実行コマンド
  ローカル / Docker:

  ```bash
  docker compose exec web bin/rails weekly_reviews:send
  ```
  本番 Scheduler:
  ```
  bundle exec rails weekly_reviews:send
  ```
  Cron設定:
  0 10 * * 1
  ※ Render CronはUTC基準のため、毎週月曜10:00 UTC = 毎週月曜19:00 JST

## 確認したこと
  - docker compose exec web bin/rails weekly_reviews:send を実行
  - LINEに週次レビューが届くことを確認
  - 表現一覧リンクが本文の最後に1表示されることを確認

## 補足
 - 配信対象は line_user_id が存在するユーザーです
  - line_friend / line_notifications_enabled は、LINE側の最新状態をDBだけでは正確に判断できないため、今回の配信条件には
    含めていません

## 関連Issue
closes #127
closes #128 
closes #129 