### PR TITLE
feat:プライバシーポリシーページの追加

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,9 @@
+class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only:[:privacy, :terms]
+
+  def privacy
+  end
+
+  def terms
+  end
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only:[:privacy, :terms]
+  skip_before_action :authenticate_user!, only: [ :privacy, :terms ]
 
   def privacy
   end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -20,9 +20,9 @@
         <h2 class="card-title">リマインダー通知設定</h2>
       </div>
 
-      <div class="card bg-base-100 shadow mb-4 p-3">
+      <%= link_to privacy_path, class:"card bg-base-100 shadow mb-4 p-3" do %>
         <h2 class="card-title">利用規約</h2>
-      </div>
+      <% end %>
 
       <div class="card bg-base-100 shadow mb-4 p-3">
         <h2 class="card-title">サービスポリシー</h2>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -20,7 +20,7 @@
         <h2 class="card-title">リマインダー通知設定</h2>
       </div>
 
-      <%= link_to privacy_path, class:"card bg-base-100 shadow mb-4 p-3" do %>
+      <%= link_to terms_path, class:"card bg-base-100 shadow mb-4 p-3" do %>
         <h2 class="card-title">利用規約</h2>
       <% end %>
 

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,0 +1,95 @@
+<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-center text-lg md:text-4xl sm:text-2xl mb-6">
+      <%= t('.title') %>
+    </h1>
+
+      <div class="card bg-base-100 shadow mb-4 p-4 sm:p-5 md:p-6">
+        <div class="text-md sm:text-lg md:text-lg">
+          <p class="leading-8 pb-3">Capture Your Day（以下「本アプリ」）は、ユーザーの個人情報の取り扱いについて、以下の方針に基づき取り扱います。</p>
+        
+          <section class="space-y-3 border-t border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">1. 取得する情報</h2>
+            <p class="leading-8">本アプリの利用に際しては、お客様から以下の情報を取得します。</p>
+            <ul class="list-disc pl-6 leading-8" >
+                <li>氏名（ニックネームやペンネームを含む）</li>
+                <li>メールアドレス</li>
+                <li>投稿された日記・添削結果・保存された表現</li>
+                <li>「LINEアカウント連携」を利用した場合に取得するユーザー識別子（ユーザーID）、表示名、プロフィール画像などのプロフィール情報</li>
+                <li>ユーザーが本アプリ公式LINEアカウントへ送信したメッセージ内容（LINE連携手続きやお問い合わせ対応に必要な範囲で確認します）</li>
+                <li>利用者が本サービス上に入力・保存または送信する文章そのほかのデータ</li>
+                <li>Cookieそのほかの類似技術により取得される識別情報</li>
+            </ul>
+          </section>
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">2. 利用目的</h2>
+            <p class="leading-8">本アプリは、取得した情報を以下の目的で利用します。</p>
+            <ul class="list-disc pl-6">
+              <li>本アプリへの登録、本人確認および認証のため</li>
+              <li>本アプリの機能、サービス提供および改善のため</li>
+              <li>ユーザーに合わせたパーソナライズ体験の提供のため</li>
+              <li>AIによる添削機能および学習支援機能の提供のため</li>
+              <li>LINEアカウント連携ユーザーに対して、週次レポート等の学習支援通知を送信するため</li>
+              <li>お問い合わせへの対応のため</li>
+              <li>本アプリの規約や法令に違反する行為に対応するため</li>
+            </ul>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">3. 外部サービスの利用</h2>
+            <p class="leading-8">本アプリは、サービス提供のために以下の外部サービスを利用する場合があります。</p>
+            <ul class="list-disc pl-6">
+              <li>OpenAI</li>
+              <li>Line Messaging API</li>
+            </ul>
+            <p class="leading-8">
+            本アプリは、AI添削機能やLINE通知機能を提供するため、サービス提供に必要な範囲で、ユーザーが入力・送信した情報の一部をOpenAIやLINE
+            Messaging API等の外部サービスに送信する場合があります。
+            送信された情報は、各外部サービスの利用規約およびプライバシーポリシーに従って取り扱われます。
+            </p>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">4. 第三者提供および外部委託</h2>
+            <p class="leading-8">
+            個人情報は法令に基づく場合を除き、本人の同意なく第三者に提供することはありません。
+            ただし、サービス提供に必要な範囲で、外部サービス提供事業者に情報を送信または取り扱いを委託する場合があります。
+            </p>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">5. 安全管理</h2>
+            <p class="leading-8">本アプリは、取得した個人情報について、不正アクセス、紛失、漏えい等の防止、そのほかの安全管理のために、合理的な措置を講じます</p>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">6. 個人情報の開示・訂正・削除等</h2>
+            <p class="leading-8">
+            ユーザーは本アプリが保有する自己の個人情報について、開示、訂正、削除、利用停止を求めることができます。
+            ご希望の場合は、お問い合わせ先までご連絡ください。
+            </p>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">7. プライバシーポリシーの変更</h2>
+            <p class="leading-8">
+            本アプリは、必要に応じて本プライバシーポリシーを変更することがあります。
+            最新の内容は、こちらのページでご確認ください。
+            </p>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-xl ">8. お問い合わせ</h2>
+            <p class="leading-8">
+            質問や不明点がございましたら、以下までご連絡ください<br>
+            メールアドレス：capture.your.day24@gmail.com
+            </p>
+          </section>
+
+          <p class="text-base-content/70 pt-6">制定日：2026年6月8日</p>
+
+        </div>
+      </div>
+  </div>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,8 +1,8 @@
 <footer class="bg-primary bg-opacity-80 border-t border-base-300 py-4">
   <nav class="flex items-center justify-center gap-4 mb-1">
-    <%= link_to "利用規約", "#", 
+    <%= link_to "利用規約", terms_path, 
     class: "link link-hover text-base text-base-content hover:text-base-content transition-colors" %>
-    <%= link_to "プライバシーポリシー", "#", 
+    <%= link_to "プライバシーポリシー", privacy_path, 
     class: "link link-hover text-base text-base-content hover:text-base-content transition-colors" %>
   </nav>
   <p class="text-base text-center text-base-content mt-3">

--- a/app/views/top/_main.html.erb
+++ b/app/views/top/_main.html.erb
@@ -157,9 +157,9 @@ flex items-center justify-center py-16 px-5 md:px-10">
 <%# フッター %>
 <footer class="py-5 px-10 bg-base-200 border border-base-300 text-center">
   <div class="flex items-center justify-center gap-4 mb-1">
-  <%= link_to "利用規約", "#", 
+  <%= link_to "利用規約", terms_path, 
      class: "link link-hover text-sm text-cream-400 hover:text-cream-600 transition-colors" %>
-  <%= link_to "プライバシーポリシー", "#", 
+  <%= link_to "プライバシーポリシー", privacy_path, 
      class: "link link-hover text-sm text-cream-400 hover:text-cream-600 transition-colors" %>
   </div>
   <p class="text-sm text-cream-400">© 2026 Capture Your Day</p>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -52,6 +52,9 @@ ja:
       next: "次へ"
       last: "最後"
       truncate: "..."
+  pages:
+    privacy:
+      title: "プライバシーポリシー"
   
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,8 @@ Rails.application.routes.draw do
   resources :journal_corrections, only: [ :index, :show ]
   resource :mypage, only: [ :show ]
   resource :line_connection, only: [ :show, :create, :destroy ]
-
+  get 'privacy', to: 'pages#privacy'
+  get 'terms', to: 'pages#terms'
 
   # テスト用ルーティング　あとで削除する
   # get '/test500', to: 'application#test500'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,8 @@ Rails.application.routes.draw do
   resources :journal_corrections, only: [ :index, :show ]
   resource :mypage, only: [ :show ]
   resource :line_connection, only: [ :show, :create, :destroy ]
-  get 'privacy', to: 'pages#privacy'
-  get 'terms', to: 'pages#terms'
+  get "privacy", to: "pages#privacy"
+  get "terms", to: "pages#terms"
 
   # テスト用ルーティング　あとで削除する
   # get '/test500', to: 'application#test500'


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
プライバシーポリシーページの追加をしました。

## 変更内容

- PagesControllerを追加
- プライバシーポリシーページを追加
- ルーティングを追加(/privacy, /terms)
- フッターの「プライバシーポリシー」リンクをprivacy_pathに変更

## 確認方法
- プライバシーポリシーページが表示されりこと
- 未ログイン状態でも'/privacy'にアクセスできること

## 関連Issue
closes #57 