### PR TITLE
fix:文字のサイズの調整

### DIFF
--- a/app/views/devise/shared/_auth_wrapper.html.erb
+++ b/app/views/devise/shared/_auth_wrapper.html.erb
@@ -10,8 +10,8 @@
       <!-- <h1 class="font-cormorant text-4xl font-bold text-base-content">Capture Your Day</h1> -->
 
       
-      <!--<p class="text-base sm:text-lg md:text-xl text-base-content-muted mt-4"> Write your thoughts. Track your growth. </p>-->
-      <p class="text-base sm:text-lg md:text-xl text-base-content-muted mt-4"> Express your thoughts. Expand your world. </p>
+      <!--<p class="text-base sm:text-md md:text-lg text-base-content-muted mt-4"> Write your thoughts. Track your growth. </p>-->
+      <p class="text-base sm:text-md md:text-lg text-base-content-muted mt-4"> Express your thoughts. Expand your world. </p>
     </div>
     <div class="bg-base-100 border border-base-300 rounded-3xl p-10 shadow-sm">
     <!-- <div class="bg-washi rounded-3xl border border-washi-border shadow-md p-8"> -->

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,15 +8,15 @@
 
     <div class="flex justify-center gap-2 mb-4">
       <div class=" bg-secondary rounded-2xl p-3 text-center flex-1">
-        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @total_count %><span class="text-xs sm:text-lg font-medium"> 件</span></p>
+        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @total_count %><span class="text-xs sm:text-md font-medium"> 件</span></p>
         <p class="text-sm sm:text-md md:text-lg text-base-content-muted ">総投稿数</p>
       </div>
       <div class="bg-secondary rounded-2xl p-3 text-center flex-1">
-        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @total_learning_count %><span class="text-xs sm:text-lg font-medium"> フレーズ</span></p>
+        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @total_learning_count %><span class="text-xs sm:text-md font-medium"> フレーズ</span></p>
         <p class="text-sm text-base-content-muted sm:text-md md:text-lg">学んだ表現</p>
       </div>
       <div class="bg-secondary rounded-2xl p-3 text-center flex-1">
-        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @streak_count %><span class="text-xs sm:text-lg font-medium"> 日</span></p>
+        <p class="text-xl sm:text-2xl md:text-3xl font-semibold text-primary"><%= @streak_count %><span class="text-xs sm:text-md font-medium"> 日</span></p>
         <p class="text-sm sm:text-md md:text-lg text-base-content-muted">連続投稿日数</p>
       </div>
     </div>
@@ -37,14 +37,14 @@
     </div>
     <div class="bg-secondary rounded-2xl p-5 mb-4">
       <%# 今日の気持ちを英語にしてみよう %>
-      <p class="font-bold font-sans text-base text-center text-success sm:text-lg md:text-2xl mb-1">
+      <p class="font-bold font-sans text-base text-center text-success sm:text-md md:text-2xl mb-1">
         今日、心が動いたことは？
       </p>
-      <p class="text-center text-base sm:text-lg md:text-xl text-primary mb-2">
+      <p class="text-center text-base sm:text-md md:text-lg text-primary mb-2">
         日本語でも英語でも、気持ちを書き残してみよう
       </p>
       <div class="flex justify-center">
-        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base sm:text-lg md:text-xl" %>
+        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base sm:text-md md:text-lg" %>
       </div>
     </div>
   
@@ -59,12 +59,12 @@
              <%= link_to journal_path(journal) do %>
             <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-3">
             
-            <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-lg flex gap-2">
+            <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-md flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
               <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
     
-            <p class="text-base-content mb-3 line-clamp-2 text-base sm:text-lg md:text-xl">
+            <p class="text-base-content mb-3 line-clamp-2 text-base sm:text-md md:text-lg">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -13,7 +13,7 @@
           <%= link_to journal_correction_path(journal_correction),
             class:"block border border-base-300 bg-base-100 rounded-lg px-2 py-1 sm:px-4 py-3" do %>
           <%# 日付 %>
-            <div class="font-bold text-base-content/70 flex items-center gap-3 mb-2 sm:text-lg">
+            <div class="font-bold text-base-content/70 flex items-center gap-3 mb-2 sm:text-md">
               <span>
                 <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
               </span>
@@ -25,7 +25,7 @@
 
         <div class="mb-2">
           <% journal_correction.mistakes.first(2).each do |mistake| %>
-            <p class="font-semibold text-base sm:text-lg md:text-xl"><%= mistake.learning_points["pattern"] %></p>
+            <p class="font-semibold text-base sm:text-md md:text-lg"><%= mistake.learning_points["pattern"] %></p>
             <p class="text-base-content sm:text-md md:text-lg">【意味】<%= mistake.learning_points["meaning"] %></p>
           
             <!--<% if mistake.learning_points["related_phrases"].present? %>

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <!-- 曜日 -->
-    <div class="mt-4 grid grid-cols-7 gap-2 text-center text-sm sm:text-lg md:text-xl">
+    <div class="mt-4 grid grid-cols-7 gap-2 text-center text-sm sm:text-md md:text-lg">
       <% [ "月", "火", "水", "木", "金", "土", "日"].each do |day| %>
         <div class="px-2 py-1 text-center font-medium text-primary">
           <%= day %>
@@ -25,7 +25,7 @@
     </div>
 
     <!-- カレンダー本体 -->
-    <div class="mt-1 grid grid-cols-7 gap-2 text-base sm:text-lg md:text-xl">
+    <div class="mt-1 grid grid-cols-7 gap-2 text-base sm:text-md md:text-lg">
       <% day = @calendar_start %>
       <% while day <= @calendar_end %>
         <% journals = @journals_by_date[day] || [] %>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -42,7 +42,7 @@
             </div>
             <%# 本文 %>
             <%= link_to journal_path(journal) do %>
-            <p class="text-base sm:text-lg md:text-xl mb-3 line-clamp-2">
+            <p class="text-base sm:text-md md:text-lg mb-3 line-clamp-2">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
             <% end %>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -34,7 +34,7 @@
         <div class="bg-error/10 border-b border-red-100 px-4">
           <h2 class="font-semibold text-base md:text-lg text-error py-2">元の文章 </h2>
         </div>  
-        <p class="text-base sm:text-lg md:text-xl px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
+        <p class="text-base sm:text-md md:text-lg px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
     </div>
   
     <% if @journal_correction.present? %>
@@ -42,7 +42,7 @@
     <% end %>
 
     <div class="flex mt-5 gap-5">
-    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base sm:text-lg md:text-xl" %>
+    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base sm:text-md md:text-lg" %>
     <%= button_to "この日記を削除",
         journal_path(@journal), method: :delete, form: { data: { turbo_confirm: "この日記を削除しますか?"}}, class: "btn btn-error" %>
     </div>

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -5,7 +5,7 @@
       <%= t('.title') %>
     </h1>
 
-  <p class="mb-6 text-base-content text-center sm:text-lg md:text-2xl">
+  <p class="mb-6 text-base-content text-center sm:text-md md:text-2xl">
     LINEアカウントを連携すると、週ごとの振り返りレポートをお届けします。
   </p>
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -6,7 +6,7 @@
     </h1>
       <div class="card bg-base-100 shadow mb-4 p-3">
         <h2 class="card-title">プロフィール</h2>
-        <div class="flex flex-col gap-2 text-md sm:text-lg md:text-lg">
+        <div class="flex flex-col gap-2 text-md sm:text-md md:text-lg">
           <p>名前：<%= current_user.name %></p>
           <p>メールアドレス：<%= current_user.email %></p>
         </div>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -6,7 +6,7 @@
     </h1>
 
       <div class="card bg-base-100 shadow mb-4 p-4 sm:p-5 md:p-6">
-        <div class="text-md sm:text-lg md:text-lg">
+        <div class="text-md sm:text-md md:text-lg">
           <p class="leading-8 pb-3">Capture Your Day（以下「本アプリ」）は、ユーザーの個人情報の取り扱いについて、以下の方針に基づき取り扱います。</p>
         
           <section class="space-y-3 border-t border-b border-base-300 py-6">

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -5,7 +5,7 @@
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
-          <p class="text-base sm:text-lg md:text-xl px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
+          <p class="text-base sm:text-md md:text-lg px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
     </div>
 
     <% if @journal_correction.mistakes.present? %>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
日記詳細、日記一覧、表現詳細、表現一覧画面の文字サイズを調整しました。

## 変更内容
  - 日記本文・一覧プレビューの文字サイズを調整
  - 表現詳細画面の学習表現・補足文の文字サイズを調整

## 確認方法
  - 日記詳細画面の表示確認
  - 日記一覧画面の表示確認
  - 表現詳細画面の表示確認
  - 表現一覧画面の表示確認