### PR TITLE
feat: 日記一覧に月移動ナビゲーションを追加

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -20,7 +20,7 @@ class JournalsController < ApplicationController
       else
         @journals = @journals.where(posted_date: @current_month.all_month)
       end
-      
+
     @journals = @journals.order(posted_date: :desc, id: :desc).page(params[:page]).per(10)
   end
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -2,11 +2,25 @@ class JournalsController < ApplicationController
   helper MistakesHelper
   before_action :authenticate_user!
   def index
-    # @journals =current_user.journals.order(created_at: :desc)
+    @year = params[:year]&.to_i || Date.current.year
+    @month = params[:month]&.to_i || Date.current.month
+    @current_month = Date.new(@year, @month, 1)
+
+    prev_month = @current_month.prev_month
+    next_month = @current_month.next_month
+
+    @prev_year = prev_month.year
+    @prev_month = prev_month.month
+    @next_year = next_month.year
+    @next_month = next_month.month
+
     @journals =current_user.journals.includes(:journal_correction)
       if params[:posted_date].present?
         @journals = @journals.where(posted_date: params[:posted_date])
+      else
+        @journals = @journals.where(posted_date: @current_month.all_month)
       end
+      
     @journals = @journals.order(posted_date: :desc, id: :desc).page(params[:page]).per(10)
   end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-title font-bold text-2xl text-primary sm:text-3xl md:text-3xlxl mb-3 leading-tight">
+    <h1 class="font-title font-bold text-2xl text-primary sm:text-3xl md:text-3xl mb-3 leading-tight">
     <%= current_user.name %>'s Journal
     </h1>
 

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -25,8 +25,8 @@
 
         <div class="mb-2">
           <% journal_correction.mistakes.first(2).each do |mistake| %>
-            <p class="font-semibold text-base sm:text-md md:text-lg"><%= mistake.learning_points["pattern"] %></p>
-            <p class="text-base-content sm:text-md md:text-lg">【意味】<%= mistake.learning_points["meaning"] %></p>
+            <p class="font-semibold text-sm sm:text-base"><%= mistake.learning_points["pattern"] %></p>
+            <p class="text-base-content sm:text-base">【意味】<%= mistake.learning_points["meaning"] %></p>
           
             <!--<% if mistake.learning_points["related_phrases"].present? %>
               <% mistake.learning_points["related_phrases"].each do |phrase| %> 

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     
-    <h1 class="font-sans font-semibold text-lg md:text-3xlxl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>
     
@@ -71,7 +71,7 @@
                 
                 <%# 学んだ表現 %>
                 <div class="bg-secondary p-3 mb-1">
-                  <p class="text-lg md:text-2xl font-bold text-primary">
+                  <p class="text-lg md:text-xl font-bold text-primary">
                     <%= mistake.learning_points["pattern"] %>
                   </p>
                   <p class="text-primary">
@@ -80,28 +80,28 @@
                 </div>
 
                 <%# 添削前・添削後の文章 %>
-                <div class="mx-3 text-base-content mb-2 text-base md:text-lg">今回の添削</div>
+                <div class="mx-3 text-base-content mb-2 text-sm md:text-base">今回の添削</div>
                   <div class="mx-3 bg-error/10 rounded-xl px-2 py-2 mb-2">
-                    <p class=" text-error text-base md:text-lg">添削前：<%= mistake.original_text %></p>
+                    <p class=" text-error text-sm md:text-base">添削前：<%= mistake.original_text %></p>
                 </div>
                 <div class="mx-3 bg-secondary rounded-xl px-2 py-2">
-                  <p class=" text-primary font-semibold text-base md:text-lg">添削後：<%= mistake.corrected_text %></p> 
+                  <p class=" text-primary font-semibold text-base md:text-md">添削後：<%= mistake.corrected_text %></p> 
                 </div>
                 <hr class="border-primary mb-2 mt-2">
 
               <%# ほかの表現・言い回し %>
-              <p class="mx-3 text-base-content mb-2 text-base md:text-lg">似た表現・言い回し</p>
+              <p class="mx-3 text-base-content mb-2 text-sm md:text-base">似た表現・言い回し</p>
 
               <% Array(mistake.learning_points["related_phrases"]).compact.each do |phrase| %>
                 <div class="mx-3 bg-base-100 border border-base-300 rounded-2xl p-3 mb-2">
-                  <p class="text-lg font-bold"><%= phrase["phrase"] %></p>
-                  <p class="text-base md:text-lg"><%= phrase["meaning"] %></p>
-                  <p class=" text-primary font-semibold text-base md:text-lg"><%= phrase["example"] %></p>
+                  <p class="text-sm  sm:text-base font-bold"><%= phrase["phrase"] %></p>
+                  <p class="text-sm sm:text-base"><%= phrase["meaning"] %></p>
+                  <p class=" text-primary font-semibold text-sm sm:text-base"><%= phrase["example"] %></p>
                 </div> 
               <% end %>
                 <%= link_to "この日記を見る", 
                     @journal_correction.journal,
-                    class:"text-base md:text-lg mx-3 flex items-center justify-center btn btn-sm border-primary text-primary hover:bg-primary hover:text-white mb-2" %>                     
+                    class:"text-sm md:text-base mx-3 flex items-center justify-center btn btn-sm border-primary text-primary hover:bg-primary hover:text-white mb-2" %>                     
                 </div>
             <% end %>  
           </div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -3,25 +3,19 @@
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-bold font-sans text-lg md:text-3xlxl sm:text-2xl text-center font-cream-500 mb-6">
-    日記一覧
+    日記一覧 (<%= @current_month.strftime("%Y年%-m月") %>)
     </h1>
-
-      <!-- <div class="actions mb-4">
-    <%= link_to "日記を書く", new_journal_path(posted_date:Date.current), class:"btn btn-primary" %>
-    </div> -->
+    <%= render "shared/month_navigation",
+        current_month: @current_month,
+        prev_year: @prev_year,
+        prev_month: @prev_month,
+        next_year: @next_year,
+        next_month: @next_month,
+        path: ->(params) { journals_path(params) } %>
+  
       <% if@journals.any? %>
         <%# 日記一覧をループ %>
         <% @journals.each do |journal| %>
-          <%#　1件ずつ枠で囲む  %>
-          <!--<div class="text-right">
-            <%= button_to "削除",
-                journal_path(journal),
-                method: :delete,
-                form: {data: {turbo_confirm:"この日記を削除しますか？"}},
-                class: "btn btn-sm text-sm text-center hover:opacity-70"
-            %>
-          </div>-->
-
           <div class="border border-base-300 bg-base-100 rounded-lg py-3 mb-2 px-4">
 
             <div class="flex items-center gap-3">
@@ -42,7 +36,7 @@
             </div>
             <%# 本文 %>
             <%= link_to journal_path(journal) do %>
-            <p class="text-base sm:text-md md:text-lg mb-3 line-clamp-2">
+            <p class="text-sm sm:text-base mb-3 line-clamp-2">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
             <% end %>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-3 sm:px-6 md:px-10"> 
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-sans font-semibold text-lg md:text-3xlxl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>
 </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     <%# ページタイトル %>
-    <h1 class="font-sans font-semibold text-lg md:text-3xlxl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>
 
@@ -17,7 +17,7 @@
   </div>
   <%# 元の文章（日本語でもそのまま表示） %>
   <%# スマホ：折りたたみ表示 %>
-    <div class="font-semibold mb-2 text-base md:text-lg">
+    <div class="font-semibold mb-2 text-basemd">
       <%= @journal.posted_date.strftime("%Y/%m/%d") %>
     </div>
       <div class="md:hidden collapse collapse-arrow border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">
@@ -32,9 +32,9 @@
        <%# 枠開始 %>
       <div class="hidden md:block border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">
         <div class="bg-error/10 border-b border-red-100 px-4">
-          <h2 class="font-semibold text-base md:text-lg text-error py-2">元の文章 </h2>
+          <h2 class="font-semibold text-sm md:text-base text-error py-2">元の文章 </h2>
         </div>  
-        <p class="text-base sm:text-md md:text-lg px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
+        <p class="text-sm sm:text-base px-5 py-4 whitespace-pre-line"><%= @journal_correction&.original_text %></p>
     </div>
   
     <% if @journal_correction.present? %>
@@ -42,7 +42,7 @@
     <% end %>
 
     <div class="flex mt-5 gap-5">
-    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base sm:text-md md:text-lg" %>
+    <%= link_to '日記一覧に戻る' , journals_path, class:"btn btn-primary flex-1 text-base sm:text-md" %>
     <%= button_to "この日記を削除",
         journal_path(@journal), method: :delete, form: { data: { turbo_confirm: "この日記を削除しますか?"}}, class: "btn btn-error" %>
     </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -17,7 +17,7 @@
   </div>
   <%# 元の文章（日本語でもそのまま表示） %>
   <%# スマホ：折りたたみ表示 %>
-    <div class="font-semibold mb-2 text-basemd">
+    <div class="font-semibold mb-2 text-base">
       <%= @journal.posted_date.strftime("%Y/%m/%d") %>
     </div>
       <div class="md:hidden collapse collapse-arrow border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">

--- a/app/views/mistakes/index.html.erb
+++ b/app/views/mistakes/index.html.erb
@@ -2,6 +2,6 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-bold font-title text-lg md:text-3xlxl sm:text-2xl text-center font-cream-500 mb-6">
+    <h1 class="font-bold font-title text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-6">
     My Journal
     </h1>

--- a/app/views/mistakes/show.html.erb
+++ b/app/views/mistakes/show.html.erb
@@ -3,6 +3,6 @@
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <%# ページタイトル %>
-    <h1 class="font-sans font-bold text-lg md:text-3xlxl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-lg md:text-3xlxl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6">
       <%= t('.title') %>
     </h1>
       <div class="card bg-base-100 shadow mb-4 p-3">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,13 +1,13 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-center text-lg md:text-3xlxl sm:text-2xl mb-6">
+    <h1 class="font-sans font-semibold text-center text-lg md:text-3xl sm:text-2xl mb-6">
       <%= t('.title') %>
     </h1>
 
       <div class="card bg-base-100 shadow mb-4 p-4 sm:p-5 md:p-6">
         <div class="text-sm sm:text-base">
-          <p class="leading-7 pb-3">Capture Your Day（以下「本アプリ」といいます。）は、ユーザーの個人情報の取り扱うことを重要な責務と考え、以下の方針に基づき個人情報を取り扱います。</p>
+          <p class="leading-7 pb-3">Capture Your Day（以下「本アプリ」といいます。）は、ユーザーの個人情報を適切に取り扱うことを重要な責務と考え、以下の方針に基づき個人情報を取り扱います。</p>
         
           <section class="space-y-3 border-t border-b border-base-300 py-6">
             <h2 class="font-semibold text-base sm:text-xl ">1. 取得する情報</h2>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,17 +1,17 @@
     <div class="border border-base-300 bg-base-100 rounded-2xl mb-4">
       <div class="flex items-center gap-2 bg-secondary border-b border-forest-200 px-4 ">
-        <h2 class="font-semibold text-base md:text-lg py-2 text-primary">添削後の文章</h2>
+        <h2 class="font-semibold text-sm sm:text-base py-2 text-primary">添削後の文章</h2>
         <span class="badge badge-soft badge-success text-white px-5 py-4">
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
-          <p class="text-base sm:text-md md:text-lg px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
+          <p class="text-sm sm:text-base px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
     </div>
 
     <% if @journal_correction.mistakes.present? %>
       <div class="flex justify-between items-center mb-3">
-        <h2 class="text-lg md:text-2xl font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
-          <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-primary  bg-secondary text-primary hover:bg-primary hover:text-white text-base md:text-lg" %>
+        <h2 class="text-lg md:text-xl font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
+          <%= link_to "表現を復習する", @journal_correction, class: "btn btn-sm border-primary  bg-secondary text-primary hover:bg-primary hover:text-white text-sm sm:text-base" %>
       </div>
 
           <% @journal_correction.mistakes.each do |mistake| %>
@@ -22,12 +22,12 @@
                   <%= mistake_type_label(mistake.mistake_type) %>
                 </span>
                 <% if mistake.learning_points["pattern"].present? %>
-                  <p class="text-lg md:text-2xl font-semibold mb-1 text-primary">
+                  <p class="text-lg md:text-xl font-semibold mb-1 text-primary">
                     <%= mistake.learning_points["pattern"] %>
                   </p>
                 <% end %>
                 <% if mistake.learning_points["meaning"].present? %>
-                  <p class="text-base md:text-lg text-primary">
+                  <p class="text-sm sm:text-base text-primary">
                     <%= mistake.learning_points["meaning"] %> 
                   </p>
                 <% end %>
@@ -35,16 +35,16 @@
                 
                 <%# ボディ %>
                 <div class="px-4 py-3">
-                  <p class="text-base-content/70 mb-1 text-base md:text-lg">今回の添削</p>
-                  <p class="mx-2 text-base md:text-lg bg-error/10 px-3 py-2 text-error mb-2 rounded-xl">  
+                  <p class="text-base-content/70 mb-1 text-sm sm:text-base">今回の添削</p>
+                  <p class="mx-2 text-sm sm:text-base bg-error/10 px-3 py-2 text-error mb-2 rounded-xl">  
                   <%= mistake.original_text %></p>
-                  <p class="mx-2 text-base md:text-lg  bg-base-200  text-primary font-semibold border-forest-200 rounded-xl px-3 py-2">
+                  <p class="mx-2 text-sm sm:text-base  bg-base-200  text-primary font-semibold border-forest-200 rounded-xl px-3 py-2">
                   <%= mistake.corrected_text %></p>
 
                 <%# ポイント %>
                 <% if mistake.explanation.present? %>
-                  <p class="text-base-content/70 mt-2 text-base md:text-lg">ポイント</p>
-                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content sm:text-md md:text-lg">
+                  <p class="text-base-content/70 mt-2 text-sm sm:text-base">ポイント</p>
+                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content sm:text-base">
                     <%= mistake.explanation %>
                   </div>
                 <% end %>

--- a/app/views/shared/_month_navigation.html.erb
+++ b/app/views/shared/_month_navigation.html.erb
@@ -1,0 +1,22 @@
+<div class="flex items-center justify-end gap-2 mb-4">
+  <%= link_to "前月",
+      path.call(year: prev_year, month: prev_month),
+      class: "btn btn-sm border-forest-200 bg-secondary hover:bg-forest-200" %>
+  
+  <div class="text-center">
+    <% unless current_month == Date.current.beginning_of_month %>
+      <%= link_to "当月",
+          path.call(year: Date.current.year, month: Date.current.month),
+          class: "btn btn-sm border-primary bg-primary hover:bg-forest-200" %>
+    <% end %>
+  </div>
+  
+  <!--「今月なら翌月を出さない -->
+  <% if current_month < Date.current.beginning_of_month %>
+    <%= link_to "翌月",
+        path.call(year: next_year, month: next_month),
+        class: "btn btn-sm border-forest-200 bg-secondary hover:bg-forest-200" %>
+  <% else %>
+    <span class="w-20"></span>
+  <% end %>
+</div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
日記一覧ページで表示月を切り替えられるように、月移動ナビゲーションを追加しました。
## 変更内容
  - 日記一覧で `year` / `month` パラメータを受け取るように変更
  - 表示中の月の日記のみ一覧表示するように変更
  - 前月・当月・翌月へ移動する共通パーシャルを追加
  - 今月表示時は翌月ボタンを表示しないように調整
  - 日記詳細・表現詳細など一部画面の文字サイズを調整
 
## 確認方法
  - 日記一覧で当月の日記が表示されること
  - 前月ボタンで前月の日記一覧へ移動できること
  - 過去月では翌月ボタンが表示されること
  - 今月表示時は翌月ボタンが表示されないこと

## 関連Issue
closes #192 