### PR TITLE
feat: 表現一覧に月移動ナビゲーションを追加

### DIFF
--- a/app/controllers/journal_corrections_controller.rb
+++ b/app/controllers/journal_corrections_controller.rb
@@ -2,12 +2,26 @@ class JournalCorrectionsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @year = params[:year]&.to_i || Date.current.year
+    @month = params[:month]&.to_i || Date.current.month
+    @current_month = Date.new(@year, @month, 1)
+
+    previous_month = @current_month.prev_month
+    next_month = @current_month.next_month
+
+    @prev_year = previous_month.year
+    @prev_month = previous_month.month
+    @next_year = next_month.year
+    @next_month = next_month.month
+
     @journal_corrections = current_user
                            .journal_corrections
                            .includes(:journal, :mistakes)
                            .joins(:journal)
-                           .where(journals: { posted_date: Date.current.all_month })
-                           .order("journals.posted_date DESC, journal_corrections.journal_id DESC").page(params[:page]).per(10)
+                           .where(journals: { posted_date: @current_month.all_month })
+                           .order("journals.posted_date DESC, journal_corrections.journal_id DESC")
+                           .page(params[:page])
+                           .per(10)
   end
 
   def show

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -6,11 +6,11 @@ class JournalsController < ApplicationController
     @month = params[:month]&.to_i || Date.current.month
     @current_month = Date.new(@year, @month, 1)
 
-    prev_month = @current_month.prev_month
+    previous_month = @current_month.prev_month
     next_month = @current_month.next_month
 
-    @prev_year = prev_month.year
-    @prev_month = prev_month.month
+    @prev_year = previous_month.year
+    @prev_month = previous_month.month
     @next_year = next_month.year
     @next_month = next_month.month
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -40,11 +40,11 @@
       <p class="font-bold font-sans text-base text-center text-success sm:text-md md:text-2xl mb-1">
         今日、心が動いたことは？
       </p>
-      <p class="text-center text-base sm:text-md md:text-lg text-primary mb-2">
+      <p class="text-center text-base sm:text-md text-primary mb-2">
         日本語でも英語でも、気持ちを書いてみましょう
       </p>
       <div class="flex justify-center">
-        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base sm:text-md md:text-lg" %>
+        <%= link_to "日記を書いてみる", new_journal_path, class:"btn btn-primary w-64 text-base sm:text-md" %>
       </div>
     </div>
   
@@ -61,10 +61,10 @@
             
             <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-md flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
-              <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
+              <span class="inline-flex items-center bg-secondary text-primary text-sm rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
     
-            <p class="text-base-content mb-3 line-clamp-2 text-base sm:text-md md:text-lg">
+            <p class="text-base-content mb-3 line-clamp-2 text-sm sm:text-base">
               <%= journal.journal_correction&.rewritten_text || journal.body %>
             </p>
           
@@ -77,7 +77,7 @@
           <% end %>
           <% else %>
             <div class="bg-base-100 border border-base-300 rounded-2xl p-8 text-center">
-              <p class="font-sans text-base-content-muted text-xl">最初の1ページです🌱</p>
+              <p class="font-sans text-base-content-muted text-lg">最初の1ページです🌱</p>
             </div>
         <% end %>
         

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,9 +1,17 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-2 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-semibold font-sans text-lg md:text-3xlxl sm:text-2xl text-center mb-6">
+    <h1 class="font-semibold font-sans text-lg md:text-3xl sm:text-2xl text-center mb-6">
      <%= t('.title') %>
     </h1>
+
+    <%= render "shared/month_navigation",
+        current_month: @current_month,
+        prev_year: @prev_year,
+        prev_month: @prev_month,
+        next_year: @next_year,
+        next_month: @next_month,
+        path: ->(params) { journal_corrections_path(params) } %>
 
     <% if @journal_corrections.any? %>
       <div class="space-y-2 mb-2">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-2 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-bold font-sans text-lg md:text-3xlxl sm:text-2xl text-center font-cream-500 mb-6">
+    <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-6">
     日記一覧 (<%= @current_month.strftime("%Y年%-m月") %>)
     </h1>
     <%= render "shared/month_navigation",

--- a/app/views/shared/_month_navigation.html.erb
+++ b/app/views/shared/_month_navigation.html.erb
@@ -5,7 +5,7 @@
   
   <div class="text-center">
     <% unless current_month == Date.current.beginning_of_month %>
-      <%= link_to "当月",
+      <%= link_to "今月",
           path.call(year: Date.current.year, month: Date.current.month),
           class: "btn btn-sm border-primary bg-primary hover:bg-forest-200" %>
     <% end %>
@@ -16,7 +16,5 @@
     <%= link_to "翌月",
         path.call(year: next_year, month: next_month),
         class: "btn btn-sm border-forest-200 bg-secondary hover:bg-forest-200" %>
-  <% else %>
-    <span class="w-20"></span>
   <% end %>
 </div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
表現一覧ページで表示月を切り替えられるように、月移動ナビゲーションを追加しました。

## 変更内容
- 表現一覧で year / month パラメータを受け取るように変更
- 表示中の月の表現のみ一覧表示するように変更
- 今月表示時は翌月ボタンを表示しないように調整

## 確認方法
- 表現一覧で当月の日記が表示されること
- 前月ボタンで前月の表現一覧へ移動できること
- 過去月では翌月ボタンが表示されること
- 今月表示時は翌月ボタンが表示されないこ

## 関連Issue
closes #193 