### PR TITLE
feat:プロフィール編集機能を追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,11 +3,23 @@ class UsersController < ApplicationController
   end
 
   def edit
+    @user = current_user
   end
 
   def update
+    if current_user.update(user_params)
+      redirect_to mypage_path, success: "プロフィールを更新しました。"
+    else
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name)
   end
 end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -6,10 +6,15 @@
     </h1>
       <div class="card bg-base-100 shadow mb-4 p-3">
         <h2 class="card-title">プロフィール</h2>
-        <div class="flex flex-col gap-2 text-md sm:text-md md:text-lg">
+        <div class="flex flex-col gap-2 text-sm sm:text-base mt-2">
           <p>名前：<%= current_user.name %></p>
+          <div class="flex items-center justify-between gap-3">
           <p>メールアドレス：<%= current_user.email %></p>
+           <%= link_to "編集", edit_user_path, class:"btn btn-sm btn-secondary px-6 mr-4 hover:bg-base-300 hover:text-base-400" %>
+          </div>
         </div>
+
+
       </div>
 
       <%= link_to line_connection_path, class:"card bg-base-100 shadow mb-4 p-3 hover:bg-base-300 transition" do %>

--- a/app/views/shared/_month_navigation.html.erb
+++ b/app/views/shared/_month_navigation.html.erb
@@ -1,13 +1,13 @@
 <div class="flex items-center justify-end gap-2 mb-4">
   <%= link_to "前月",
       path.call(year: prev_year, month: prev_month),
-      class: "btn btn-sm border-forest-200 bg-secondary hover:bg-forest-200" %>
+      class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200" %>
   
   <div class="text-center">
     <% unless current_month == Date.current.beginning_of_month %>
       <%= link_to "今月",
           path.call(year: Date.current.year, month: Date.current.month),
-          class: "btn btn-sm border-primary bg-primary hover:bg-forest-200" %>
+          class: "btn btn-sm border-primary bg-primary text-white hover:bg-forest-200" %>
     <% end %>
   </div>
   
@@ -15,6 +15,6 @@
   <% if current_month < Date.current.beginning_of_month %>
     <%= link_to "翌月",
         path.call(year: next_year, month: next_month),
-        class: "btn btn-sm border-forest-200 bg-secondary hover:bg-forest-200" %>
+        class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200" %>
   <% end %>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,24 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div>
-  <h1 class="font-bold text-4xl">Users#edit</h1>
-  <p>Find me in app/views/users/edit.html.erb</p>
-</div>
+<div class="flex-grow px-2 sm:px-6 md:px-10">
+  <div class="max-w-xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-6">
+      <%= t('.title') %>
+    </h1>
+
+      <div class="card bg-base-100 shadow mb-4 p-5">
+        <%= form_with model: @user, url: user_path, method: :patch do |f| %>
+          <div class="mb-4 flex items-center gap-4">
+            <%= f.label :name, "名前", class: "w-24 font-medium"  %>
+            <%= f.text_field :name, class: "input input-bordered w-full" %>
+          </div>
+
+          <div class="flex justify-end gap-2">
+            <%= link_to "戻る", mypage_path, class:"btn btn-outline" %>
+            <%= f.submit "保存する", class:"btn btn-primary" %>
+          </div>
+        <% end %>
+      </div>
+
+    </div>
+  </div>
+

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -42,6 +42,9 @@ ja:
   mypages:
     show:
       title: マイページ
+  users:
+    edit:
+      title: プロフィール編集
   line_connections:
     show:
       title: LINE通知設定


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
マイページのプロフィールよりプロフィール画面へ遷移し、ユーザー名を変更できるようにしました。

## 変更内容
 - マイページのプロフィール欄に編集リンクを追加
   プロフィール編集画面を作成
 - `UsersController#edit` / `#update` で名前を編集できるように実装

## 確認方法
- マイページのプロフィールからプロフィール編集画面へ遷移でいること
- 名前を変更し、保存したあとにマイページに戻ること
- マイページに変更後の名前が反映されていること

## 関連Issue
closes #116
