### PR TITLE
feat:プロフィール画像の設定(ローカル環境)

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name)
+    params.require(:user).permit(:name, :profile_image)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   has_many :mistakes, dependent: :destroy
   has_one :notification_setting, dependent: :destroy
   has_many :journal_corrections, dependent: :destroy
+  has_one_attached :profile_image
 
   devise :database_authenticatable,
          :registerable,

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -7,6 +7,13 @@
       <div class="card bg-base-100 shadow mb-4 p-3">
         <h2 class="card-title">プロフィール</h2>
         <div class="flex flex-col gap-2 text-sm sm:text-base mt-2">
+          <% if current_user.profile_image.attached? %>
+            <%= image_tag current_user.profile_image, class: "w-16 h-16 rounded-full object-cover" %> 
+          <% else %>
+            <div class="w-16 h-16 rounded-full bg-base-300 flex items-center justify-center font-semibold">
+            <%= current_user.name.to_s.first || "?"  %>
+            </div>
+          <% end %>
           <p>名前：<%= current_user.name %></p>
           <div class="flex items-center justify-between gap-3">
           <p>メールアドレス：<%= current_user.email %></p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,7 +2,6 @@
 <header class="navbar bg-base-100 border-b border-base-300 fixed top-0 left-0 right-0 z-50 px-4 h-16">
   <div class="navbar-start">
     <%= link_to "Capture Your Day", (user_signed_in? ? authenticated_root_path : unauthenticated_root_path), class:"font-title text-md sm:text-lg md:text-xl font-bold text-base-content leading-tight"%>
-    <%# link_to "Home", root_path, class: "btn btn-ghost normal-case text-xl" %>
   </div>
 
 <%# PC用 #%>
@@ -14,9 +13,18 @@
     <%= link_to "日記一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
-    <%= link_to "マイページ", mypage_path, class: "btn btn-ghost normal-case text-md md:text-md" %>
-
-    <div data-controller="theme" class="flex items-center">
+    <%# link_to "マイページ", mypage_path, class: "btn btn-ghost normal-case text-md md:text-md" %>
+  <% else %>
+    <%# 未ログイン時は何も表示しない %>
+  <% end %>
+  </div>
+</div>
+      <!-- navbar-end -->
+<%# 右側：ボタン・スマホメニュー %>
+<div class="navbar-end gap-2">
+  <div class="hidden md:flex gap-2">
+      <% if user_signed_in? %>
+   <div data-controller="theme" class="flex items-center">
       <label class="swap swap-rotate btn btn-ghost btn-sm btn-circle"
              aria-label="テーマを切り替える"
              title="ダークモード">
@@ -55,18 +63,17 @@
         <span class="swap-on text-xl">🌙</span> -->
       </label>
     </div>
-  </div>
-  <% else %>
-    <%# 未ログイン時は何も表示しない %>
-  <% end %>
-      <!-- <span class="font-english text-xl text-base-content">Capture Your Day</span> -->
-      <!--<h1 class="font-cormorant text-2xl font-bold text-base-content">Capture Your Day</h1> -->
-</div>
-      <!-- navbar-end -->
-<%# 右側：ボタン・スマホメニュー %>
-<div class="navbar-end gap-2">
-  <div class="hidden md:flex gap-2">
-      <% if user_signed_in? %>
+
+      <!-- プロフィール画像表示-->
+        <%= link_to mypage_path, class:"btn btn-ghost btn-circle" do %>
+          <% if current_user.profile_image.attached? %>
+            <%= image_tag current_user.profile_image, class:"w-9 h-9 rounded-full object-cover" %>
+          <% else %>
+            <div class="w-9 h-9 rounded-full bg-base-300 flex items-center justify-center text-sm font-semibold">
+              <%= current_user.name.to_s.first.presence || "?" %>
+            </div>
+          <% end %>
+        <% end %>
         <%= link_to t('.logout'), destroy_user_session_path, data: { turbo_method: :delete, turbo_confirm: "ログアウトしますか？" }, class: "btn btn-primary font-bold text-white hover:opacity-70 text-base md:text-md" %>
       <% else %>
         <div class = "flex gap-4">
@@ -90,12 +97,25 @@
     </label>
     <ul tabindex="0" class="dropdown-content menu p-2 bg-base-100 rounded-box w-52 mt-2 border border-base-300">
       <% if user_signed_in? %>
+        <li>
+        <%= link_to mypage_path, class:"flex items-center gap-3" do %>
+          <% if current_user.profile_image.attached? %>
+            <%= image_tag current_user.profile_image, class: "w-9 h-9 rounded-full object-cover" %>
+          <% else %>
+          <div class="w-9 h-9 rounded-full bg-base-300 flex items-center justify-center text-sm font-semibold">
+            <%= current_user.name.to_s.first.presence || "?" %>
+          </div>  
+          <% end %>
+          <span>マイページ</span>
+        <% end %>
+        </li>
+
         <li><%= link_to "ホーム", authenticated_root_path %></li>
         <li><%= link_to "日記を書く", new_journal_path %></li>
         <li><%= link_to "日記一覧", journals_path %></li>
         <li><%= link_to "カレンダー", calendar_journals_path %></li>
         <li><%= link_to "表現一覧", journal_corrections_path %></li>
-        <li><%= link_to "マイページ", mypages_show_path %></li>
+        <!-- <li><%# link_to "マイページ", mypages_show_path %></li> -->
 
         <li>
         <div data-controller="theme">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,8 +7,17 @@
 
       <div class="card bg-base-100 shadow mb-4 p-5">
         <%= form_with model: @user, url: user_path, method: :patch do |f| %>
-          <div class="mb-4 flex items-center gap-4">
-            <%= f.label :name, "名前", class: "w-24 font-medium"  %>
+          <div class="mb-4">
+            <%= f.label :profile_image, "プロフィール画像", class:"block font-medium mb-2" %>
+           
+            <% if current_user.profile_image.attached? %>
+              <%= image_tag current_user.profile_image, class:"w-16 h-16 rounded-full object-cover mb-3" %>
+            <% end %>
+
+            <%= f.file_field :profile_image, accept: "image/png,image/jpeg", class: "file-input file-input-bordered file-input-primary w-full" %>
+          </div>
+          <div class="mb-4">  
+            <%= f.label :name, "名前", class: "block font-medium mb-2"  %>
             <%= f.text_field :name, class: "input input-bordered w-full" %>
           </div>
 

--- a/db/migrate/20260612041555_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20260612041555_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,81 +10,111 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_21_095439) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_12_041555) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.bigint "record_id", null: false
+    t.string "record_type", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.string "content_type"
+    t.datetime "created_at", null: false
+    t.string "filename", null: false
+    t.string "key", null: false
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "journal_corrections", force: :cascade do |t|
+    t.text "advice"
+    t.datetime "created_at", null: false
     t.bigint "journal_id", null: false
-    t.bigint "user_id", null: false
+    t.json "mistake_patterns"
+    t.json "native_phrases"
     t.text "original_text", null: false
     t.text "rewritten_text", null: false
     t.json "strengths"
-    t.json "mistake_patterns"
-    t.text "advice"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "native_phrases"
+    t.bigint "user_id", null: false
     t.index ["journal_id"], name: "index_journal_corrections_on_journal_id"
     t.index ["user_id"], name: "index_journal_corrections_on_user_id"
   end
 
   create_table "journals", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.date "posted_date", null: false
-    t.integer "mood"
-    t.string "title"
     t.text "body", null: false
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "mood"
+    t.date "posted_date", null: false
+    t.string "title"
     t.integer "tone"
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_journals_on_user_id"
   end
 
   create_table "mistakes", force: :cascade do |t|
-    t.bigint "journal_id", null: false
-    t.bigint "user_id", null: false
-    t.text "original_text", null: false
     t.text "corrected_text"
-    t.text "explanation"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "mistake_type"
+    t.text "explanation"
     t.bigint "journal_correction_id"
+    t.bigint "journal_id", null: false
     t.jsonb "learning_points", default: {}, null: false
+    t.integer "mistake_type"
+    t.text "original_text", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["journal_correction_id"], name: "index_mistakes_on_journal_correction_id"
     t.index ["journal_id"], name: "index_mistakes_on_journal_id"
     t.index ["user_id"], name: "index_mistakes_on_user_id"
   end
 
   create_table "notification_settings", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.boolean "reminder_enabled", default: false
-    t.time "notification_time"
-    t.integer "scene_type", default: 0
     t.datetime "created_at", null: false
+    t.time "notification_time"
+    t.boolean "reminder_enabled", default: false
+    t.integer "scene_type", default: 0
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_notification_settings_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
+    t.string "avatar"
+    t.datetime "created_at", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "name", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "avatar"
-    t.string "line_user_id"
-    t.boolean "line_notifications_enabled", default: false
-    t.string "line_link_code"
     t.boolean "line_friend", default: false, null: false
+    t.string "line_link_code"
+    t.boolean "line_notifications_enabled", default: false
+    t.string "line_user_id"
+    t.string "name", null: false
+    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "journal_corrections", "journals"
   add_foreign_key "journal_corrections", "users"
   add_foreign_key "journals", "users"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ローカル環境でプロフィール画像の設定ができるようにしました。

## 変更内容
  - Active Storageを導入
  - プロフィール編集画面に画像アップロード欄を追加
  - マイページにプロフィール画像を表示
  - ヘッダーとスマホメニューにプロフィール画像を表示
  - 画像未設定時は名前の頭文字または `?` を表示

## 確認方法
  - [ ] プロフィール編集画面から画像を選択して保存できる
  - [ ] 保存した画像がマイページに表示される
  - [ ] 保存した画像がヘッダーに表示される

## 関連Issue
closes #204 