### PR TITLE
feat：本番環境のプロフィール画像保存先をS3に設定

### DIFF
--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -127,6 +127,7 @@ class JournalPromptBuilder
     - reusable diary phrases
     - phrase chunks native speakers commonly use
     - expressions that help the learner say feelings more naturally
+
     When creating the pattern:
     - Preserve the actual main verb if it is useful or corrected.
     - Preserve key prepositions and collocations.
@@ -150,7 +151,6 @@ class JournalPromptBuilder
     - more than + to + 動詞
 
     Good:
-    - I'm flying to + 場所
     - My flight leaves at + 時刻
     - arrive at + 場所 by + 時刻
     - the bus that leaves at + 時刻
@@ -167,8 +167,7 @@ class JournalPromptBuilder
     Good learning point:
     pattern: to + 動詞 more than to + 動詞
     meaning: 〜することより、〜すること
-    explanation: more than で2つの行動を比べるときは、前後の文法の形をそろえると自然です。to + 動詞 と比べるなら、more
-    than の後ろも to + 動詞 にします。動名詞と比べるなら、more than の後ろも動名詞にします。
+    explanation: more than で2つの行動を比べるときは、前後の文法の形をそろえると自然です。to + 動詞 と比べるなら、more than の後ろも to + 動詞 にします。動名詞と比べるなら、more than の後ろも動名詞にします。
 
     IMPORTANT:
     The corrected sentence may be natural and flexible, but the learning point must be a reusable natural English expression, not a description of how the sentence was translated.
@@ -226,7 +225,6 @@ class JournalPromptBuilder
       If the expression requires a following clause, write "+ 文(主語 + 動詞)".
       Do not omit required subjects.
 
-
     Do not return incomplete patterns.
 
     BAD:
@@ -250,10 +248,6 @@ class JournalPromptBuilder
       + 名詞 / 動名詞
       + 人
       + 文(主語 + 動詞)
-
-    Classification rules:
-    - mistake_type must be exactly one of: grammar, spelling, word_choice, expression, translation.
-    - Use detailed categories such as tense, preposition, article, word_order, collocation, infinitive, gerund only in learning_points.review_tag.
 
     Only create a note when it teaches a useful reusable point for the learner.
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,8 +37,8 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-  # config.active_storage.service = :amazon
+  # config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,14 +5,15 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
+  
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon:
+  service: S3
+  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  region: <%= ENV["AWS_REGION"] %>
+  bucket: <%= ENV["S3_BUCKET"] %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
本番環境のプロフィール画像の保存先をAmazon S3に設定しました。

## 変更内容
  - 本番環境の Active Storage 保存先を `:amazon` に変更
  - S3 接続情報を Render の環境変数から読み込むように設定

 ## Render に必要な環境変数
  - `AWS_ACCESS_KEY_ID`
  - `AWS_SECRET_ACCESS_KEY`
  - `AWS_REGION`
  - `S3_BUCKET`

## 確認方法
 - [ ] 本番環境でアップロード画像が S3 に保存される

## 補足
 - Render では IAM ロールではなく、S3 用の IAM ユーザーのアクセスキーを環境変数に設定しています。
  - ローカル / テスト環境では S3 ではなく Active Storage の `local` / `test` を使用します。

## 関連Issue
closes #60 
closes #61 
closes #62 