### PR TITLE
fix:ヘッダーのホームボタンを削除する

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
 <div class="navbar-center hidden md:flex">
   <% if user_signed_in? %>
   <div class="flex items-center gap-1 flex-nowrap">
-    <%= link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
+    <%# link_to "ホーム", authenticated_root_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "日記を書く", new_journal_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "日記一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
@@ -110,7 +110,7 @@
         <% end %>
         </li>
 
-        <li><%= link_to "ホーム", authenticated_root_path %></li>
+        <!-- <li><%# link_to "ホーム", authenticated_root_path %></li> -->
         <li><%= link_to "日記を書く", new_journal_path %></li>
         <li><%= link_to "日記一覧", journals_path %></li>
         <li><%= link_to "カレンダー", calendar_journals_path %></li>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ヘッダーのホームボタンを削除しました。

## 背景
ヘッダーのロゴをクリックするとホーム画面に遷移するため、
ホームボタンを削除し、ホーム画面への導線をロゴで統一することにしました。

## 変更内容
- `_header.html.erb`からホームボタンを除外

## 確認方法
- ヘッダーに「ホーム」の文言が表示されていないことを確認
- ヘッダーのロゴを押下するとホーム画面へ遷移することを確認

## 関連Issue
closes #