### PR TITLE
fix:余白の調整

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-title font-bold text-2xl text-primary sm:text-3xl md:text-3xl mb-3 leading-tight">
     <%= current_user.name %>'s Journal
@@ -35,7 +35,7 @@
         <% end %>
      <% end %>
     </div>
-    <div class="bg-secondary rounded-2xl p-5 mb-2">
+    <div class="bg-secondary rounded-2xl p-5 mb-4">
       <%# 今日の気持ちを英語にしてみよう %>
       <p class="font-bold font-sans text-base text-center text-success sm:text-md md:text-2xl mb-1">
         今日、心が動いたことは？
@@ -57,11 +57,11 @@
           <% @journals.each do |journal| %>
             <%# 1件ずつ枠で囲む %>
              <%= link_to journal_path(journal) do %>
-            <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-2">
+            <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-4">
             
             <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-md flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
-              <span class="inline-flex items-center bg-secondary text-primary text-sm rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
+              <span class="inline-flex items-center bg-secondary text-primary text-xs sm:text-sm rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
     
             <p class="text-base-content mb-3 line-clamp-2 text-sm sm:text-base">
@@ -83,7 +83,7 @@
         
         <div class="mt-5 mb-4">
           <%= link_to "すべての日記を見る", journals_path, 
-              class: "btn btn-primary text-white hover: text-forest-300 w-full text-base md:text-lg" %>
+              class: "btn btn-primary text-white hover:text-forest-300 w-full text-base md:text-lg" %>
         </div>
     </div>
   </div>

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-semibold font-sans text-lg md:text-3xl sm:text-2xl text-center mb-6">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-4 pb-6 sm:pt-6 md:px-0">
+    <h1 class="font-semibold font-sans text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
      <%= t('.title') %>
     </h1>
 
@@ -14,14 +14,16 @@
         path: ->(params) { journal_corrections_path(params) } %>
 
     <% if @journal_corrections.any? %>
-      <div class="space-y-2 mb-2">
+      <div class="space-y-3 mb-2">
       <%# journal_correctionsをループ %>
         <%# 1件ずつ枠で囲む %>
         <% @journal_corrections.each do |journal_correction| %>
           <%= link_to journal_correction_path(journal_correction),
-            class:"block border border-base-300 bg-base-100 rounded-lg px-2 py-1 sm:px-4 py-3" do %>
+            class:"block border border-base-300 bg-base-100 rounded-lg px-2 py-3 sm:px-4" do %>
           <%# 日付 %>
-            <div class="font-bold text-base-content/70 flex items-center gap-3 mb-2 sm:text-md">
+          <div class="mb-2">
+            <div class="font-bold text-base-content/70 flex items-center gap-3 sm:text-md">
+  
               <span>
                 <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
               </span>
@@ -29,19 +31,11 @@
                   <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
               </div>
            </div>
-      
-
+          </div>
         <div class="mb-2">
           <% journal_correction.mistakes.first(2).each do |mistake| %>
             <p class="font-semibold text-sm sm:text-base"><%= mistake.learning_points["pattern"] %></p>
             <p class="text-base-content sm:text-base">【意味】<%= mistake.learning_points["meaning"] %></p>
-          
-            <!--<% if mistake.learning_points["related_phrases"].present? %>
-              <% mistake.learning_points["related_phrases"].each do |phrase| %> 
-                <p><%= phrase["phrase"] %></p>
-                <p class="text-base-content">【意味】<%= phrase["meaning"] %></p>
-              <% end %>
-            <% end %>-->
           <% end %>
         </div>
           <% end %>
@@ -52,7 +46,7 @@
       <div role="alert" class="alert alert-info">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-        </svg>最初の1ページです🌱今日の気持ちを書いてみましょう
+        </svg>この月の学びはまだありません。今日の気持ちを書いてみましょう
         <span></span>
       </div>
     <% end %>

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -1,8 +1,8 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
     
@@ -30,7 +30,7 @@
         添削トーン：<%= t("activerecord.attributes.journal.tones.#{@journal_correction.journal.tone}")  %>
         </span>
       </div>
-        <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-2">
+        <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-4">
           <p>
           <%= @journal_correction.rewritten_text %>
           </p>

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -1,5 +1,5 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-5xl mx-auto w-full pt-2 pb-6 sm:pt-6 md:px-2">
     <div class="w-full bg-base-100/80 p-4 sm:p-6 rounded-3xl">
     

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,8 +1,8 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-6">
+    <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-4 sm:mb-6">
     日記一覧 (<%= @current_month.strftime("%Y年%-m月") %>)
     </h1>
     <%= render "shared/month_navigation",
@@ -16,13 +16,13 @@
       <% if@journals.any? %>
         <%# 日記一覧をループ %>
         <% @journals.each do |journal| %>
-          <div class="border border-base-300 bg-base-100 rounded-lg py-3 mb-2 px-4">
+          <div class="border border-base-300 bg-base-100 rounded-lg py-3 mb-3 px-4">
 
             <div class="flex items-center gap-3">
-              <span class="font-bold text-base-content/70 mb-2">
+              <span class="font-bold text-base-content/70">
                 <%= journal.posted_date.strftime("%Y/%m/%d") %>
               </span>
-              <span class="inline-flex items-center bg-secondary text-primary text-sm md:text-md rounded-full px-2 py-1">
+              <span class="inline-flex items-center bg-secondary text-primary text-xs sm:text-sm rounded-full px-2 py-1">
                 添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
               </span>
               <span class="ml-auto">
@@ -30,7 +30,7 @@
                   journal_path(journal),
                   method: :delete,
                   form: {data: {turbo_confirm:"この日記を削除しますか？"}},
-                  class: "btn btn-sm text-sm text-center bg-base-300 hover:opacity-70"
+                  class: "btn btn-sm text-xs sm:text-sm text-center bg-base-300 hover:opacity-70"
               %>
             </span>
             </div>
@@ -49,7 +49,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
         </svg>
-        <span>最初の1ページです🌱今日の気持ちを書いてみましょう</span>
+        <span>この月の日記はまだありません。今日の気持ちを書いてみましょう</span>
       </div>
       <% end %>
     </div>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,8 +1,8 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-3 sm:px-6 md:px-10"> 
-   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+<div class="flex-grow px-4 sm:px-6 md:px-10"> 
+   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6"><%= t('.title') %></h1>
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>
 </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -1,8 +1,8 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <%# ページタイトル %>
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-6">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/mistakes/index.html.erb
+++ b/app/views/mistakes/index.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-bold font-title text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-6">
+    <h1 class="font-bold font-title text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-4 sm:mb-6">
     My Journal
     </h1>

--- a/app/views/mistakes/show.html.erb
+++ b/app/views/mistakes/show.html.erb
@@ -1,8 +1,8 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-   <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <%# ページタイトル %>
-    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-6">
+    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-6">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
       <div class="card bg-base-100 shadow mb-4 p-3">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-center text-lg md:text-3xl sm:text-2xl mb-6">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title,t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-center text-lg sm:text-2xl md:text-3xl mb-6">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
+    <h1 class="font-sans font-semibold text-center text-lg sm:text-2xl md:text-3xl mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/shared/_month_navigation.html.erb
+++ b/app/views/shared/_month_navigation.html.erb
@@ -1,13 +1,13 @@
 <div class="flex items-center justify-end gap-2 mb-4">
   <%= link_to "前月",
       path.call(year: prev_year, month: prev_month),
-      class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200" %>
+      class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200 text-xs sm:text-sm" %>
   
   <div class="text-center">
     <% unless current_month == Date.current.beginning_of_month %>
       <%= link_to "今月",
           path.call(year: Date.current.year, month: Date.current.month),
-          class: "btn btn-sm border-primary bg-primary text-white hover:bg-forest-200" %>
+          class: "btn btn-sm border-primary bg-primary text-white hover:bg-forest-200 text-xs sm:text-sm" %>
     <% end %>
   </div>
   
@@ -15,6 +15,6 @@
   <% if current_month < Date.current.beginning_of_month %>
     <%= link_to "翌月",
         path.call(year: next_year, month: next_month),
-        class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200" %>
+        class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200 text-xs sm:text-sm" %>
   <% end %>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:title, t('.title', default: APP_NAME)) %>
-<div class="flex-grow px-2 sm:px-6 md:px-10">
+<div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-6">
+    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
スマホ表示の各画面の余白を調整しました。

## 変更内容
  - スマホ表示時の左右余白を調整
  - 各ページ下部の余白を調整
  - 一部画面のタイトル下余白をスマホ表示向けに調整
  - 一覧カード間の余白を調整
  - 月別一覧でデータがない場合の表示文言を調整

## 確認方法
  - スマホ幅で各画面を表示し、コンテンツが画面端に寄りすぎていないことを確認
  - 日記一覧・表現一覧のカード間に適度な余白があることを確認
  - タイトルとコンテンツの間隔が広すぎないことを確認

## 関連Issue
closes #