### PR TITLE
 fix: フラッシュ表示時の背景色の差を解消

### DIFF
--- a/app/views/top/_main.html.erb
+++ b/app/views/top/_main.html.erb
@@ -1,4 +1,4 @@
-<section class="relative overflow-hidden bg-sage-50 min-h-screen
+<section class="relative overflow-hidden bg-base-200 min-h-screen
 flex items-center justify-center py-16 px-5 md:px-10">
    <%# ── 背景アイコン：星と本を薄く散らす ── %>
   <svg class="absolute inset-0 w-full h-full pointer-events-none"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ログアウト後にフラッシュメッセージが表示された際、フラッシュメッセージ部分の背景色とページ本体の背景色が異なっていたため、トップページの背景色を統一しました。

## 変更内容
  - トップページの背景色を `bg-sage-50` から `bg-base-200` に変更

## 確認方法
  - [ ] ログアウト後にフラッシュメッセージが表示される
  - [ ] フラッシュメッセージ周辺とトップページ本体の背景色に違和感がない

## 関連Issue
closes #