### PR TITLE
fix:プライバシーポリシーの修正

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -7,7 +7,8 @@
 
       <div class="card bg-base-100 shadow mb-4 p-4 sm:p-5 md:p-6">
         <div class="text-sm sm:text-base">
-          <p class="leading-7 pb-3">Capture Your Day（以下「本アプリ」といいます。）は、ユーザーの個人情報を適切に取り扱うことを重要な責務と考え、以下の方針に基づき個人情報を取り扱います。</p>
+          <p class="leading-7 pb-3">Capture Your Day（以下「本アプリ」）は、ユーザーの個人情報を大切に扱い、安心して利用いただけるよう、以下の方針に基づい
+  て管理します。</p>
         
           <section class="space-y-3 border-t border-b border-base-300 py-6">
             <h2 class="font-semibold text-base sm:text-xl ">1. 取得する情報</h2>
@@ -59,35 +60,54 @@
           </section>
 
           <section class="space-y-3 border-b border-base-300 py-6">
-            <h2 class="font-semibold text-base sm:text-xl ">5. 安全管理</h2>
-            <p class="leading-7">本アプリは、取得した個人情報について、不正アクセス、紛失、漏えい等の防止、そのほかの安全管理のために、合理的な措置を講じます。</p>
+            <h2 class="font-semibold text-base sm:text-xl">5.アクセス解析ツール</h2>
+            <p class="leading-7">
+            本アプリは、アクセス解析のために「Google Analytics」を利用しています。
+            Google Analyticsは、トラフィックデータの収集のためにCookieを使用しています。
+            トラフィックデータは匿名で収集されており、個人を特定するものではありません。
+            Cookieを無効にすることで、情報の収集を拒否することができます。<br>
+            詳しくはお使いのブラウザの設定をご確認ください。
+            </p>
+            <p class="leading-7">
+            Googleアナリティクスについて、詳しくは以下からご確認ください。
+            <%=link_to "https://marketingplatform.google.com/about/analytics/terms/jp/",
+               "https://marketingplatform.google.com/about/analytics/terms/jp/",
+               class: "link link-primary",
+               target: "_blank",
+               rel: "noopener noreferrer" %>
           </section>
 
           <section class="space-y-3 border-b border-base-300 py-6">
-            <h2 class="font-semibold text-base sm:text-xl">6. 個人情報の開示・訂正・削除等</h2>
+            <h2 class="font-semibold text-base sm:text-xl ">6. 安全管理</h2>
             <p class="leading-7">
-            ユーザーはご自身の個人情報について、開示、訂正、削除、利用停止を求めることができます。
+            本アプリは、データの漏えい、改ざん、不正アクセスなどを防ぐため、適切な安全管理を実施します。</p>
+          </section>
+
+          <section class="space-y-3 border-b border-base-300 py-6">
+            <h2 class="font-semibold text-base sm:text-xl">7. 個人情報の開示・訂正・削除等</h2>
+            <p class="leading-7">
+            ユーザーはご自身の個人情報について、開示、訂正、削除、利用停止を求めることができます。<br>
             ご希望の場合は、お問い合わせ先までご連絡ください。
             </p>
           </section>
 
           <section class="space-y-3 border-b border-base-300 py-6">
-            <h2 class="font-semibold text-base sm:text-xl">7. プライバシーポリシーの変更</h2>
+            <h2 class="font-semibold text-base sm:text-xl">8. プライバシーポリシーの変更</h2>
             <p class="leading-7">
-            本アプリは、必要に応じて本プライバシーポリシーを変更することがあります。
+            本アプリは、必要に応じて本プライバシーポリシーを変更することがあります。<br>
             最新の内容は、こちらのページでご確認ください。
             </p>
           </section>
 
           <section class="space-y-3 border-b border-base-300 py-6">
-            <h2 class="font-semibold text-xl ">8. お問い合わせ</h2>
+            <h2 class="font-semibold text-xl ">9. お問い合わせ</h2>
             <p class="leading-7">
             質問や不明点がございましたら、以下までご連絡ください。<br>
             メールアドレス：capture.your.day24@gmail.com
             </p>
           </section>
 
-          <p class="text-base-content/70 pt-6">制定日：2026年6月8日</p>
+          <p class="text-base-content/70 pt-6">最終更新日：2026年6月8日</p>
 
         </div>
       </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -11,7 +11,7 @@
       <section class="space-y-3 border-t border-b border-base-300 py-6">
         <h2 class="font-semibold text-base sm:text-lg">1. 利用規約への同意</h2>
         <p class="leading-7">
-        Capture Your Day(以下「本アプリ」といいます。)を利用することにより、
+        Capture Your Day(以下「本アプリ」)を利用することにより、
         ユーザーは本利用規約および<%= link_to "プライバシーポリシー", privacy_path, class: "link link-primary" %>に同意したものとみなされます。
         </p>
       </section>
@@ -20,7 +20,7 @@
         <h2 class="font-semibold text-base sm:text-lg">2. 機能について</h2>
         <p class="leading-7">
         本アプリでは、AIによる英作文添削や翻訳機能を提供しています。
-        これらの機能は、外部AIサービスを利用して提供されており、生成または提供される内容の正確性、完全性、有用性について保証するものではありません。
+        これらの機能は、外部AIサービスを利用して提供しており、生成または提供される内容の正確性、完全性、有用性について保証するものではありません。
         </p>
       </section>
 
@@ -28,14 +28,14 @@
         <h2 class="font-semibold text-base sm:text-lg">3. アカウント管理</h2>
         <p class="leading-7">
         アカウント情報の管理はユーザーの責任において行うものとします。
-        アカウント情報の管理不足または第三者による不正利用によって生じた損害について、運営者は故意または重大な過失がある場合を除き、責任を負いません。
+        アカウント情報の管理不足または第三者による不正利用によって生じた損害について、責任を負いません。
         </p>
       </section>
 
       <section class="space-y-3 border-b border-base-300 py-6">
         <h2 class="font-semibold text-base sm:text-lg">4. 禁止事項</h2>
         <p class="leading-7">
-        ユーザーは、ほかの利用者が安心して本サービスを利用できるよう、以下の行為を行わないものとします。
+        本アプリの利用にあたり、以下の行為を禁止します。
         </p>
         <ul class="list-disc pl-6 leading-7">
           <li>法令または公序良俗に反する行為</li>
@@ -44,21 +44,21 @@
           <li>本サービスの運営を妨げる行為</li>
           <li>虚偽の情報を登録する行為</li>
           <li>他人になりすまして利用する行為</li>
-          <li>その他、運営者が不適切と判断する行為</li>
+          <li>その他、開発者が不適切と判断する行為</li>
         </ul>
       </section>
 
       <section class="space-y-3 border-b border-base-300 py-6">
         <h2 class="font-semibold text-base sm:text-lg">5. サービスの変更・停止</h2>
         <p class="leading-7">
-        運営者は必要に応じて本アプリの内容を変更し、または提供を停止・終了することがあります。
+        開発者は必要に応じて本アプリの内容を変更し、または提供を停止・終了することがあります。
         </p>
       </section>
 
       <section class="space-y-3 border-b border-base-300 py-6">
         <h2 class="font-semibold text-base sm:text-lg">6. 知的財産権</h2>
         <p class="leading-7">
-        本アプリ内で提供される文章、画像、デザイン、ロゴそのほかのコンテンツに関する権利は、運営者または正当な権利者に帰属します。
+        本アプリ内で提供される文章、画像、デザイン、ロゴそのほかのコンテンツに関する権利は、開発者または正当な権利者に帰属します。
         これらのコンテンツの無断転載、複製または再配布はご遠慮ください。
         </p>
       </section>
@@ -66,14 +66,14 @@
       <section class="space-y-3 border-b border-base-300 py-6">
         <h2 class="font-semibold text-base sm:text-lg">7. 免責事項</h2>
         <p class="leading-7">
-        本アプリの利用により生じた損害について、運営者は故意または重大な過失がある場合を除き、責任を負わないものとします。
+        本アプリの利用により生じた損害について、開発者は故意または重大な過失がある場合を除き、責任を負わないものとします。
         </p>
       </section>
 
       <section  class="space-y-3 border-b border-base-300 py-6">
         <h2 class="font-semibold text-base sm:text-lg">8. 利用規約の変更</h2>
         <p class="leading-7">
-        運営者は、必要に応じて本利用規約を変更することがあります。
+        開発者は、必要に応じて本利用規約を変更することがあります。
         変更後の利用規約は、本アプリ上に掲載した時点で効力を生じるものとします。
         ユーザーが変更後も本アプリの利用を継続することにより、変更後の利用規約に同意したものとみなします。
         </p>
@@ -83,11 +83,11 @@
         <h2 class="font-semibold text-base sm:text-lg">9. 準拠法および管轄裁判所</h2>
         <p class="leading-7">
         本利用規約は日本法に基づいて解釈されるものとします。
-        本アプリに関して、ユーザーと運営者の間で紛争が生じた場合は、運営者の所在地を管轄する地方裁判所を第一審の専属的合意管轄裁判所とします。
+        本アプリに関して、ユーザーと開発者の間で紛争が生じた場合は、開発者の所在地を管轄する地方裁判所を第一審の専属的合意管轄裁判所とします。
         </p>
       </section>
 
-      <p class="text-base-content/70 pt-6">制定日：2026年6月8日</p>
+      <p class="text-base-content/70 pt-6">最終更新日：2026年6月19日</p>
       
       </div>
     </div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
Google Analyticsの追加に伴い、プライバシーポリシーにアクセス解析ツールの説明を追加しました。

## 変更内容
  - プライバシーポリシーにGoogle Analyticsの利用について追記
  - Cookieを使用したトラフィックデータ収集について説明を追加
  - Google Analytics利用規約へのリンクを追加
  - プライバシーポリシー内の項目番号を調整
  - プライバシーポリシー、利用規約の一部文言を修正
  - 制定日表記を最終更新日に変更

## 確認方法
  - プライバシーポリシーページの表示確認
  - Google Analytics利用規約リンクが別タブで開くことを確認

## 関連Issue
closes #