### PR TITLE
feat: SEO用のメタタグを設定

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:noindex, true) %>
 <h2>Resend confirmation instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,6 @@
 
-<%= content_for(:title, t('.title', default: "Capture Your Day")) %>
+<%= content_for(:title, t('.title', default: APP_NAME )) %>
+<% content_for(:noindex, true) %>
 <%= render "devise/shared/auth_wrapper" do %>
 <h2 class="text-2xl font-bold mb-6 text-center">
 <%= t('devise.passwords.edit.change_your_password') %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,5 +1,6 @@
 
-<%= content_for(:title, t('.title', default: "Capture Your Day")) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:noindex, true) %>
   <%= render "devise/shared/auth_wrapper" do %>
 
   <h2 class="text-2xl font-bold mb-6 text-center">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,7 @@
 <!-- 新規会員登録画面 -->
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <% content_for :hide_header, true %>
+<% content_for :noindex, true %>
 
 <%= render "devise/shared/auth_wrapper" do %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,5 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:noindex, true) %>
 <%= render "devise/shared/auth_wrapper" do %>
 <h2 class="text-2xl font-bold mb-6 text-center">
   <%= t('devise.sessions.new.sign_in') %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-4 pb-6 sm:pt-6 md:px-0">
     <h1 class="font-semibold font-sans text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-5xl mx-auto w-full pt-2 pb-6 sm:pt-6 md:px-2">
     <div class="w-full bg-base-100/80 p-4 sm:p-6 rounded-3xl">

--- a/app/views/journals/create.html.erb
+++ b/app/views/journals/create.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-sans font-bold text-4xl">Journals#create</h1>
   <p>Find me in app/views/journals/create.html.erb</p>

--- a/app/views/journals/destroy.html.erb
+++ b/app/views/journals/destroy.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Journals#destroy</h1>
   <p>Find me in app/views/journals/destroy.html.erb</p>

--- a/app/views/journals/edit.html.erb
+++ b/app/views/journals/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Journals#edit</h1>
   <p>Find me in app/views/journals/edit.html.erb</p>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10"> 
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <%# ページタイトル %>

--- a/app/views/journals/update.html.erb
+++ b/app/views/journals/update.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Journals#update</h1>
   <p>Find me in app/views/journals/update.html.erb</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,16 @@
 <html lang="ja" data-theme="color">
   <head>
     <title><%= content_for?(:title) ? yield(:title) : APP_NAME %></title>
+    <meta name="description" content="<%= content_for?(:meta_description) ? yield(:meta_description) : DEFAULT_META_DESCRIPTION %>">
+    <% if user_signed_in? || content_for?(:noindex) %>
+      <meta name="robots" content="noindex, nofollow">
+    <% end %>
+    
+    <meta property="og:site_name" content="<%= APP_NAME %>">
+    <meta property="og:title" content="<%= content_for?(:title) ? yield(:title) : APP_NAME %>">
+    <meta property="og:description" content="<%= content_for?(:meta_description) ? yield(:meta_description) : DEFAULT_META_DESCRIPTION %>">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="<%= request.original_url %>">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">

--- a/app/views/mistakes/create.html.erb
+++ b/app/views/mistakes/create.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Mistakes#create</h1>
   <p>Find me in app/views/mistakes/create.html.erb</p>

--- a/app/views/mistakes/destroy.html.erb
+++ b/app/views/mistakes/destroy.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Mistakes#destroy</h1>
   <p>Find me in app/views/mistakes/destroy.html.erb</p>

--- a/app/views/mistakes/index.html.erb
+++ b/app/views/mistakes/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-3xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->

--- a/app/views/mistakes/new.html.erb
+++ b/app/views/mistakes/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Mistakes#new</h1>
   <p>Find me in app/views/mistakes/new.html.erb</p>

--- a/app/views/mistakes/show.html.erb
+++ b/app/views/mistakes/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-3xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,4 +1,5 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for :meta_description, "Capture Your Dayのプライバシーポリシーページです。" %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,4 +1,5 @@
-<%= content_for(:title,t('.title', default: APP_NAME)) %>
+<% content_for(:title,t('.title', default: APP_NAME)) %>
+<% content_for :meta_description, "Capture Your Dayの利用規約ページです。" %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-center text-lg sm:text-2xl md:text-3xl mb-4 sm:mb-6">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,4 +1,7 @@
 
+<% content_for :title, "Capture Your Day | AI添削で英語アウトプットを習慣化" %>
+<% content_for :meta_description, "Capture Your Dayは、英語で日記を書き、AI添削と間違い表現の振り返りを通して英語アウトプットを習慣化するアプリです。" %>
+
 <% content_for :hide_auth_wrapper, true %>
 <% content_for :hide_footer, true %>
 <div class="font-sans text-base-content bg-cream-100">

--- a/app/views/users/destroy.html.erb
+++ b/app/views/users/destroy.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Users#destroy</h1>
   <p>Find me in app/views/users/destroy.html.erb</p>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-xl mx-auto pt-2 pb-6 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Users#show</h1>
   <p>Find me in app/views/users/show.html.erb</p>

--- a/app/views/users/update.html.erb
+++ b/app/views/users/update.html.erb
@@ -1,4 +1,4 @@
-<%= content_for(:title, t('.title', default: APP_NAME)) %>
+<% content_for(:title, t('.title', default: APP_NAME)) %>
 <div>
   <h1 class="font-bold text-4xl">Users#update</h1>
   <p>Find me in app/views/users/update.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,8 @@ require "rails/all"
 Bundler.require(*Rails.groups)
 
 APP_NAME = "Capture Your Day"
+DEFAULT_META_DESCRIPTION = "Capture Your Dayは、英語で日記を書き、AI添削と間違い表現の振り返りを通して英語アウトプットを習慣化するアプリです。"
+
 module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
 SEOおよびSNS共有時の表示改善のため、共通レイアウトにメタタグを追加しました。

## 変更内容
  - `meta description` の共通設定を追加
  - トップページ、利用規約、プライバシーポリシーに個別の title / description を設定
  - ログイン後ページおよび認証系ページに `noindex` を設定
   - OGPタグを追加
    - `og:site_name`
    - `og:title`
    - `og:description`
    - `og:type`
    - `og:url`

## 確認方法
  - ブラウザの開発者ツールで `<head>` 内に以下のメタタグが出力されていることを確認
    - `<meta name="description">`
    - `<meta property="og:site_name">`
    - `<meta property="og:title">`
    - `<meta property="og:description">`
    - `<meta property="og:type">`
    - `<meta property="og:url">`
  - トップページ、利用規約、プライバシーポリシーでページごとの title / description が出力されていることを確認
  - ログインページ、新規登録ページ、パスワード再設定ページで `<meta name="robots" content="noindex, nofollow">` が出力されていることを確認

## 関連Issue
closes #143 