### PR TITLE
feat:モデルのRspecテストの追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
          :rememberable,
          :validatable
 
+  validates :name, presence: true
+
   def total_journal_count
     journals.distinct.count
   end

--- a/spec/factories/journal_corrections.rb
+++ b/spec/factories/journal_corrections.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :journal_correction do
+    association :journal
+    # journalに紐づいているuserを使う
+    user { journal.user }
+
+    original_text { "I go to school yesterday." }
+    rewritten_text { "I went to school yesterday." }
+    advice { "昨日なので、動詞は過去形を使いましょう" }
+  end
+end

--- a/spec/factories/journals.rb
+++ b/spec/factories/journals.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     posted_date { Date.current }
     mood { :good }
     tone { :standard }
-    title { "My Journal" }
-    body { "Have a good day." }
+    sequence(:body) { |n| "本文#{n}" }
   end
 end

--- a/spec/factories/mistakes.rb
+++ b/spec/factories/mistakes.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :mistake do
+    association :journal_correction
+
+    journal { journal_correction.journal }
+    user { journal_correction.user }
+
+    original_text { "I go to school yesterday." }
+    corrected_text { "I went to school yesterday." }
+    mistake_type { "grammar" }
+    learning_points { { pattern: "past tense" } }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    name { "test_user" }
+    sequence(:name) { |n| "test_user#{n}" }
     sequence(:email) { |n| "user#{n}@example.com" }
     password { "password" }
     password_confirmation { "password" }

--- a/spec/models/journal_correction_spec.rb
+++ b/spec/models/journal_correction_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe JournalCorrection, type: :model do
+  describe 'バリデーションチェック' do
+    it 'すべてのフィールドが有効な場合' do
+      journal_correction = build(:journal_correction)
+      expect(journal_correction).to be_valid
+    end
+
+    it 'original_textが空白の場合、無効であること' do
+      journal_correction = build(:journal_correction, original_text: nil)
+      expect(journal_correction).to be_invalid
+      expect(journal_correction.errors[:original_text]).to include('を入力してください')
+    end
+
+    it 'rewritten_textが空白の場合、無効であること' do
+      journal_correction = build(:journal_correction, rewritten_text: nil)
+      expect(journal_correction).to be_invalid
+      expect(journal_correction.errors[:rewritten_text]).to include('を入力してください')
+    end
+  end
+
+  describe '関連付け' do
+    it 'userに紐づいていること' do
+      journal_correction = build(:journal_correction, user: nil)
+      expect(journal_correction).to be_invalid
+      expect(journal_correction.errors[:user]).to include('を入力してください')
+    end
+
+    it 'journalに紐づいていること' do
+      journal_correction = build(:journal_correction, journal: nil, user: build(:user))
+      expect(journal_correction).to be_invalid
+      expect(journal_correction.errors[:journal]).to include('を入力してください')
+    end
+  end
+end

--- a/spec/models/journal_spec.rb
+++ b/spec/models/journal_spec.rb
@@ -1,8 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Journal, type: :model do
-  it "is valid with valid attributes" do
-    # Journalを作る。そのJournalがバリデーション上有効であることを確認する
-    expect(build(:journal)).to be_valid
+  # クラス名やメソッドの処理内容などを記載す
+  describe "ジャーナリングバリデーションチェック" do
+    # テストケースの説明
+    it "すべてのフィールドが有効な場合" do
+      # Journalを作る。そのJournalがバリデーション上有効であることを確認する
+      journal = build(:journal)
+      expect(build(:journal)).to be_valid
+    end
+
+    it "本文が空白の場合は無効であること" do
+      journal = build(:journal, body: nil)
+      expect(journal).to be_invalid
+    end
+
+    it "日付が空白の場合は無効であること" do
+      journal = build(:journal, posted_date: nil)
+      expect(journal).to be_invalid
+    end
+
+    it "トーンが未設定の場合は無効であること" do
+      journal = build(:journal, tone: nil)
+      expect(journal).to be_invalid
+    end
   end
 end

--- a/spec/models/mistake_spec.rb
+++ b/spec/models/mistake_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Mistake, type: :model do
+  describe 'バリデーションチェック' do
+    it 'すべてのフィールドが有効な場合' do
+      mistake = build(:mistake)
+      expect(mistake).to be_valid
+    end
+
+    it 'original_textが空白の場合は無効' do
+      mistake = build(:mistake, original_text: nil)
+      expect(mistake).to be_invalid
+      expect(mistake.errors[:original_text]).to include('を入力してください')
+    end
+
+    it 'mistake_typeに設定できること' do
+        mistake = build(:mistake, mistake_type: 'grammar' )
+        expect(mistake.grammar?).to be true
+    end
+  end
+
+    describe '関連付けチェック' do
+      it 'userに紐づいていること' do
+        mistake = build(:mistake, user: nil)
+        expect(mistake).to be_invalid
+        expect(mistake.errors[:user]).to include('を入力してください')
+      end
+
+      it 'journalに紐づいていること' do
+        mistake = build(:mistake, journal: nil, user: build(:user))
+        expect(mistake).to be_invalid
+        expect(mistake.errors[:journal]).to include('を入力してください')
+      end
+
+      it 'journal_correctionに紐づいていること' do
+        user = build(:user)
+        journal = build(:journal, user: user)
+        mistake = build(:mistake, journal_correction: nil, journal: journal, user: user)
+        expect(mistake).to be_invalid
+        expect(mistake.errors[:journal_correction]).to include('を入力してください')
+      end
+    end
+end

--- a/spec/models/mistake_spec.rb
+++ b/spec/models/mistake_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Mistake, type: :model do
     end
 
     it 'mistake_typeに設定できること' do
-        mistake = build(:mistake, mistake_type: 'grammar' )
+        mistake = build(:mistake, mistake_type: 'grammar')
         expect(mistake.grammar?).to be true
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,41 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it "is valid with valid attributes" do
-    expect(build(:user)).to be_valid
+  describe '新規ユーザー作成チェック' do
+    it 'すべてのフィールドが有効な場合' do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+
+    it 'emailが空白の場合は無効であること' do
+      user = build(:user, email: nil)
+      expect(user).to be_invalid
+    end
+
+    it 'nameが空白の場合は無効であること' do
+      user = build(:user, name: nil)
+      expect(user).to be_invalid
+    end
+
+    it 'passwordが空白の場合は無効であること' do
+      user = build(:user, password: nil)
+      expect(user).to be_invalid
+    end
+
+    it 'emailが重複している場合は無効であること' do
+      user1 = create(:user, email: "capture@example.com")
+      user2 = build(:user, email: "capture@example.com")
+      expect(user2).to be_invalid
+      expect(user2.errors[:email]).to include('はすでに存在します')
+    end
+  end
+
+  describe 'アソシエーション' do
+    it 'journalを複数持てること' do
+      user = create(:user)
+      journal = create(:journal, user: user)
+
+      expect(user.journals).to include(journal)
+    end
   end
 end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
モデルのRSpecテストを追加しました。

## 変更内容
以下モデルのバリデーション・関連付けテストを追加
- User / Journal / JournalCorrection / Mistake のモデルspecを追加

- FactoryBotのfactoryを追加

## 確認方法
docker compose exec web bundle exec rspec

## 関連Issue
closes #220