### PR TITLE
refactor:未使用カラムの削除

### DIFF
--- a/db/migrate/20260625050242_remove_unused_columns.rb
+++ b/db/migrate/20260625050242_remove_unused_columns.rb
@@ -3,6 +3,6 @@ class RemoveUnusedColumns < ActiveRecord::Migration[8.1]
     remove_column :journal_corrections, :advice, :text
     remove_column :journal_corrections, :mistake_patterns, :json
     remove_column :journal_corrections, :native_phrases, :json
-    remove_column :journal_corrections, :strengths, :json 
+    remove_column :journal_corrections, :strengths, :json
   end
 end

--- a/db/migrate/20260625050242_remove_unused_columns.rb
+++ b/db/migrate/20260625050242_remove_unused_columns.rb
@@ -1,0 +1,8 @@
+class RemoveUnusedColumns < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :journal_corrections, :advice, :text
+    remove_column :journal_corrections, :mistake_patterns, :json
+    remove_column :journal_corrections, :native_phrases, :json
+    remove_column :journal_corrections, :strengths, :json 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_12_041555) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_25_050242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -43,14 +43,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_12_041555) do
   end
 
   create_table "journal_corrections", force: :cascade do |t|
-    t.text "advice"
     t.datetime "created_at", null: false
     t.bigint "journal_id", null: false
-    t.json "mistake_patterns"
-    t.json "native_phrases"
     t.text "original_text", null: false
     t.text "rewritten_text", null: false
-    t.json "strengths"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["journal_id"], name: "index_journal_corrections_on_journal_id"

--- a/test/fixtures/journal_corrections.yml
+++ b/test/fixtures/journal_corrections.yml
@@ -5,15 +5,9 @@ one:
   user: one
   original_text: MyText
   rewritten_text: MyText
-  strengths: 
-  mistake_patterns: 
-  advice: MyText
 
 two:
   journal: two
   user: two
   original_text: MyText
   rewritten_text: MyText
-  strengths: 
-  mistake_patterns: 
-  advice: MyText


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
未使用のカラムを削除しました。

## 変更内容
- journal_correctionから以下のカラムを削除
  advice/mistake_patterns/native_phrases/strengths

## 確認方法
  - [ ] `docker compose exec web bin/rails db:migrate`
  - [ ] `docker compose exec web bin/rails test`

## 関連Issue
closes #