### PR TITLE
feat:表現のお気に入り機能の追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,0 +1,18 @@
+class FavoritesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    # mistakes テーブル全体から、指定されたidのMistakeを1件探す
+    @mistake = Mistake.find(params[:mistake_id])
+    # ログイン中のユーザーが、そのmistakeをお気に入りする
+    current_user.favorite(@mistake)
+    # redirect_back fallback_location: mistakes_path
+  end
+
+  def destroy
+    # 「ログイン中ユーザーが作成したmistakesの中から、指定されたidのMistakeを探す
+    @mistake = current_user.mistakes.find(params[:mistake_id])
+    current_user.unfavorite(@mistake)
+    # redirect_back fallback_location: mistakes_path
+  end
+end

--- a/app/helpers/favorites_helper.rb
+++ b/app/helpers/favorites_helper.rb
@@ -1,0 +1,2 @@
+module FavoritesHelper
+end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,6 @@
+class Favorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :mistake
+
+  validates :mistake_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -3,6 +3,7 @@ class Mistake < ApplicationRecord
   belongs_to :user
   belongs_to :journal_correction
   validates :original_text, presence: true
+  has_many :favorites, dependent: :destroy
 
   enum :mistake_type, { overall: 0, grammar: 1, spelling: 2, word_choice: 3, expression: 4, translation: 5 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,9 @@ class User < ApplicationRecord
   has_one :notification_setting, dependent: :destroy
   has_many :journal_corrections, dependent: :destroy
   has_one_attached :profile_image, dependent: :destroy
+  has_many :favorites, dependent: :destroy
+  # お気に入りしたmistakes一覧(user.favoritesを経由して、favoriteに紐づくmistake)
+  has_many :favorite_mistakes, through: :favorites, source: :mistake
 
   devise :database_authenticatable,
          :registerable,
@@ -51,5 +54,17 @@ class User < ApplicationRecord
       date -= 1.day
     end
     count
+  end
+
+  def favorite(mistake)
+    favorite_mistakes << mistake
+  end
+
+  def unfavorite(mistake)
+    favorite_mistakes.destroy(mistake)
+  end
+
+  def favorite?(mistake)
+    favorite_mistakes.exists?(mistake.id)
   end
 end

--- a/app/views/favorites/create.turbo_stream.erb
+++ b/app/views/favorites/create.turbo_stream.erb
@@ -1,0 +1,4 @@
+<!-- お気に入り登録後に、☆を★へ置き換える -->
+<%= turbo_stream.replace "favorite-button-for-mistake-#{@mistake.id}" do %>
+  <%= render 'mistakes/unfavorite', mistake: @mistake %>
+<% end %>

--- a/app/views/favorites/destroy.turbo_stream.erb
+++ b/app/views/favorites/destroy.turbo_stream.erb
@@ -1,0 +1,4 @@
+<!-- お気に入り解除後に、★を☆へ置き換える -->
+<%= turbo_stream.replace "unfavorite-button-for-mistake-#{@mistake.id}" do %>
+  <%= render 'mistakes/favorite', mistake: @mistake %>
+<% end %>

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -27,7 +27,7 @@
               <span>
                 <%= journal_correction.journal.posted_date.strftime("%Y/%m/%d") %>の日記
               </span>
-              <div class="badge badge-soft badge-success badge-md text-white">
+              <div class="badge badge-success badge-md text-white">
                   <%= journal_correction.mistakes.count { |mistake| mistake.learning_points["pattern"].present? } %>つの学び
               </div>
            </div>
@@ -41,7 +41,7 @@
 
         <div class="flex justify-end items-center gap-1">
           <span class="text-sm font-semibold text-primary group-hover:text-primary-focus transition-colors">
-            詳細を見る
+            表現の詳細・類似表現を見る
           </span>
           <svg xmlns="http://www.w3.org/2000/svg"
               class="w-4 h-4 text-primary group-hover:translate-x-1 transition-transform"

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -71,14 +71,19 @@
                 
                 <%# 学んだ表現 %>
                 <div class="bg-secondary p-3 mb-1">
-                  <p class="text-lg md:text-xl font-bold text-primary">
-                    <%= mistake.learning_points["pattern"] %>
-                  </p>
-                  <p class="text-primary">
-                    <%= mistake.learning_points["meaning"] %>
-                  </p>
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="min-w-0 flex-1">
+                      <p class="text-lg md:text-xl font-bold text-primary">
+                        <%= mistake.learning_points["pattern"] %>
+                      </p>
+                      <p class="text-primary">
+                        <%= mistake.learning_points["meaning"] %>
+                      </p>
+                    </div>
+                      <%= render "mistakes/favorite_button", mistake: mistake %>
+                  </div>
                 </div>
-
+                
                 <%# 添削前・添削後の文章 %>
                 <div class="mx-3 text-base-content mb-2 text-sm md:text-base">今回の添削</div>
                   <div class="mx-3 bg-error/10 rounded-xl px-2 py-2 mb-2">

--- a/app/views/mistakes/_favorite.html.erb
+++ b/app/views/mistakes/_favorite.html.erb
@@ -1,0 +1,8 @@
+<!-- 未お気に入り状態のボタン。☆を表示する これからお気に入りにする操作-->
+<%# ☆を押すと favorites#create にPOSTリクエストを送る %>
+<%= link_to favorites_path(mistake_id: mistake.id), 
+    id: "favorite-button-for-mistake-#{mistake.id}",
+    data: { turbo_method: :post },
+    class: "btn btn-ghost btn-sm text-primary border border-primary hover:bg-primary hover:text-white" do %>
+<span class="text-base">☆ 保存</span>
+<% end %>

--- a/app/views/mistakes/_favorite_button.html.erb
+++ b/app/views/mistakes/_favorite_button.html.erb
@@ -1,0 +1,8 @@
+<!-- ☆を出すか、★を出すか判断する親partial -->
+<div class="ms-auto">
+  <% if current_user.favorite?(mistake) %>
+    <%= render 'mistakes/unfavorite', { mistake: mistake } %>
+  <% else %>
+    <%= render 'mistakes/favorite', { mistake: mistake } %>
+  <% end %>
+</div>

--- a/app/views/mistakes/_unfavorite.html.erb
+++ b/app/views/mistakes/_unfavorite.html.erb
@@ -1,0 +1,7 @@
+<!-- お気に入り済み状態のボタン。★を表示する -->
+<%= link_to favorites_path(mistake_id: mistake.id), 
+    id:"unfavorite-button-for-mistake-#{mistake.id}", 
+    data: { turbo_method: :delete },
+    class: "btn btn-primary btn-sm text-white" do %>
+  <span class="text-base">保存済み</span>
+<% end %>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,13 +1,12 @@
     <div class="border border-base-300 bg-base-100 rounded-2xl mb-4">
       <div class="flex items-center gap-2 bg-secondary border-b border-forest-200 px-4 ">
         <h2 class="font-semibold text-sm sm:text-base py-2 text-primary">添削後の文章</h2>
-        <span class="badge badge-soft badge-success text-white px-5 py-4">
+        <span class="badge badge-success text-white px-3 py-3">
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
           <p class="text-sm sm:text-base px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
     </div>
-
     <% if @journal_correction.mistakes.present? %>
       <div class="flex justify-between items-center mb-3">
         <h2 class="text-lg md:text-xl font-semibold">今回の学び(<%= @journal_correction.mistakes.size %>件)</h2>
@@ -21,18 +20,25 @@
                 <span class="badge badge-primary mb-2 p-3">
                   <%= mistake_type_label(mistake.mistake_type) %>
                 </span>
-                <% if mistake.learning_points["pattern"].present? %>
-                  <p class="text-lg md:text-xl font-semibold mb-1 text-primary">
-                    <%= mistake.learning_points["pattern"] %>
-                  </p>
-                <% end %>
-                <% if mistake.learning_points["meaning"].present? %>
-                  <p class="text-sm sm:text-base text-primary">
-                    <%= mistake.learning_points["meaning"] %> 
-                  </p>
-                <% end %>
+                <div class="flex items-start justify-between gap-3">
+                  <div class="min-w-0">
+                    <% if mistake.learning_points["pattern"].present? %>
+                    <p class="text-lg md:text-xl font-semibold mb-1 text-primary">
+                      <%= mistake.learning_points["pattern"] %>
+                    </p>
+                    <% end %>
+                    
+                    <% if mistake.learning_points["meaning"].present? %>
+                      <p class="text-sm sm:text-base text-primary">
+                        <%= mistake.learning_points["meaning"] %> 
+                      </p>
+                    <% end %>
+                    </div>
+                    <%= render 'mistakes/favorite_button', mistake: mistake %>
                 </div>
                 
+                
+                </div>
                 <%# ボディ %>
                 <div class="px-4 py-3">
                   <p class="text-base-content/70 mb-1 text-sm sm:text-base">今回の添削</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "favorites/create"
+  get "favorites/destroy"
   get "line_connections/show"
   get "mypages/show"
   get "home/index"
@@ -31,7 +33,10 @@ Rails.application.routes.draw do
   resources :journal_corrections, only: [ :index, :show ]
   resource :mypage, only: [ :show ]
   resource :line_connection, only: [ :show, :create, :destroy ]
-
+  # mistake_idを渡して、current_userのお気に入りから探して消す
+  resources :favorites, only: [ :create ] do
+    delete :destroy, on: :collection
+  end
 
   # テスト用ルーティング　あとで削除する
   # get '/test500', to: 'application#test500'

--- a/db/migrate/20260625070231_create_favorites.rb
+++ b/db/migrate/20260625070231_create_favorites.rb
@@ -1,0 +1,11 @@
+class CreateFavorites < ActiveRecord::Migration[8.1]
+  def change
+    create_table :favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :mistake, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :favorites, [ :user_id, :mistake_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_050242) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_25_070231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_050242) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "mistake_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["mistake_id"], name: "index_favorites_on_mistake_id"
+    t.index ["user_id", "mistake_id"], name: "index_favorites_on_user_id_and_mistake_id", unique: true
+    t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
   create_table "journal_corrections", force: :cascade do |t|
@@ -111,6 +121,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_050242) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "favorites", "mistakes"
+  add_foreign_key "favorites", "users"
   add_foreign_key "journal_corrections", "journals"
   add_foreign_key "journal_corrections", "users"
   add_foreign_key "journals", "users"

--- a/spec/factories/favorites.rb
+++ b/spec/factories/favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :favorite do
+    user { nil }
+    mistake { nil }
+  end
+end

--- a/spec/helpers/favorites_helper_spec.rb
+++ b/spec/helpers/favorites_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the FavoritesHelper. For example:
+#
+# describe FavoritesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe FavoritesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Favorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/favorites_spec.rb
+++ b/spec/requests/favorites_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "Favorites", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/favorites/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/favorites/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/views/favorites/create.html.tailwindcss_spec.rb
+++ b/spec/views/favorites/create.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "favorites/create.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/favorites/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/favorites/destroy.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "favorites/destroy.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
ユーザーが復習したい間違い表現を保存できるようにするため、
添削後の表現をお気に入り追加・解除できる機能を追加しました。

## 変更内容
  - `favorites` テーブルを追加
    - 同じユーザーが同じ mistake を重複してお気に入りできないようにユニーク制約を追加

  - `Favorite` モデルを追加
    - `User` と `Mistake` に紐づく中間モデルとして実装
 
  - `User` モデルにお気に入り関連のメソッドを追加
    - `favorite(mistake)`
    - `unfavorite(mistake)`
    - `favorite?(mistake)`
 
- `FavoritesController` を追加

  - 添削結果・今回の学び表示にお気に入りボタンを追加
    - 未登録時は `☆ 保存`
    - 登録済み時は `保存済み`
    - Turbo Stream でボタン部分のみ更新

## 確認方法
- ログイン中のユーザーが表現をお気に入り登録・解除できる
- 「☆ 保存」「保存済み」ボタン押下後、表示が切り替わる

## 関連Issue
closes #189 