### PR TITLE
feat:お気に入り表現一覧ページの追加

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -2,10 +2,6 @@ class FavoritesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @mistakes = current_user.favorite_mistakes
-                .includes(:journal, :journal_correction)
-                .order(created_at: :desc).page(params[:page]).per(10)
-
     @year = params[:year]&.to_i || Date.current.year
     @month = params[:month]&.to_i || Date.current.month
     @current_month = Date.new(@year, @month, 1)
@@ -17,6 +13,13 @@ class FavoritesController < ApplicationController
     @prev_month = previous_month.month
     @next_year = next_month.year
     @next_month = next_month.month
+
+    @mistakes = current_user.favorite_mistakes
+                .includes(:journal, :journal_correction)
+                .where(journals: { posted_date: @current_month.all_month })
+                .order("journals.posted_date DESC, mistakes.id DESC")
+                .page(params[:page])
+                .per(10)
   end
 
   def create

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,24 @@
 class FavoritesController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @mistakes = current_user.favorite_mistakes
+                .includes(:journal, :journal_correction)
+                .order(created_at: :desc).page(params[:page]).per(10)
+
+    @year = params[:year]&.to_i || Date.current.year
+    @month = params[:month]&.to_i || Date.current.month
+    @current_month = Date.new(@year, @month, 1)
+
+    previous_month = @current_month.prev_month
+    next_month = @current_month.next_month
+
+    @prev_year = previous_month.year
+    @prev_month = previous_month.month
+    @next_year = next_month.year
+    @next_month = next_month.month
+  end
+
   def create
     # mistakes テーブル全体から、指定されたidのMistakeを1件探す
     @mistake = Mistake.find(params[:mistake_id])

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -1,0 +1,88 @@
+<% content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-4 sm:px-6 md:px-10">
+  <div class="max-w-4xl mx-auto pt-4 pb-6 sm:pt-6 md:px-0">
+
+    <h1 class="font-semibold font-sans text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">
+      <%= t('.title') %>
+    </h1>
+    
+    <%= render "shared/month_navigation",
+        current_month: @current_month,
+        prev_year: @prev_year,
+        prev_month: @prev_month,
+        next_year: @next_year,
+        next_month: @next_month,
+        path: ->(params) { favorites_path(params) } %>
+
+    <% if @mistakes.any? %>
+      <div class="mb-2">
+        <%# @mistakesをループ %>
+        <%# 1件ずつ枠で囲む %>
+        <% @mistakes.each do |mistake| %>
+        
+        <div class="border border-primary bg-base-100 rounded-2xl mb-3">
+        
+              <details class="collapse collapse-arrow bg-base-100 border border-base-300" name="my-accordion-det-1">
+                <summary class="collapse-title bg-secondary">
+                  <p class="font-base-content/70 text-sm">
+                  <%= mistake.journal.posted_date.strftime("%Y/%m/%d") %>の日記
+                  </p>
+                  <p class="font-semibold">
+                    <%= mistake.learning_points["pattern"] %>
+                  </p>
+                  <p class="text-sm sm:text-base">
+                    <%= mistake.learning_points["meaning"] %>
+                  </p>
+                </summary>
+                <div class="collapse-content text-sm">
+                  <p class="mb-1 mt-1">
+                  今回の添削
+                  </p>
+                  <p class="text-error mb-1">
+                    <%= mistake.original_text %>
+                  </p>
+                  <p class="text-primary mb-1">
+                    <%= mistake.corrected_text %>
+                  </p>
+                  <hr class="border-primary mb-2 mt-2">
+                  <p class="mb-1">
+                  似た表現・言い回し
+                  </p>
+                    <div>
+                    <% Array(mistake.learning_points["related_phrases"]).each do |phrase| %>
+                        <div class="bg-base-100 border border-base-300 rounded-2xl p-3 mb-2">
+                        <p class="font-semibold">
+                          <%= phrase["phrase"] %>
+                        </p>
+                        <p class="text-xs sm:text-sm">
+                          <%= phrase["meaning"] %>
+                        </p>
+                        <p class="text-primary font-semibold">
+                          <%= phrase["example"] %>
+                        </p>
+                        </div>
+                    <% end %>
+                    <%= link_to "この日記を見る",
+                                journal_path(mistake.journal),
+                                class: "btn btn-outline btn-sm border border-primary hover:bg-primary hover:text-white hover:border-primary" %>
+                    </div>
+              </details>
+            
+              </div>
+
+        <% end %>
+        </div>
+        
+      </div>
+   
+  </div>
+  <%= paginate @mistakes, window: 3 %>
+  <% else %>
+      <div role="alert" class="alert alert-info">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+        </svg>
+        <span>表現がまだ保存されていません。</span>
+      </div>
+   <% end %>
+</div>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -79,7 +79,7 @@
   <%= paginate @mistakes, window: 3 %>
   <% else %>
       <div role="alert" class="alert alert-info">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-6 w-6 shrink-0 stroke-current">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="h-5 w-5 shrink-0 stroke-current">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
         </svg>
         <span>表現がまだ保存されていません。</span>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -13,6 +13,7 @@
     <%= link_to "日記一覧", journals_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "カレンダー", calendar_journals_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%= link_to "表現一覧", journal_corrections_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
+    <%= link_to "保存した表現", favorites_path, class: "btn btn-ghost normal-case text-sm md:text-md" %>
     <%# link_to "マイページ", mypage_path, class: "btn btn-ghost normal-case text-md md:text-md" %>
   <% else %>
     <%# 未ログイン時は何も表示しない %>
@@ -115,6 +116,7 @@
         <li><%= link_to "日記一覧", journals_path %></li>
         <li><%= link_to "カレンダー", calendar_journals_path %></li>
         <li><%= link_to "表現一覧", journal_corrections_path %></li>
+        <li><%= link_to "保存した表現", favorites_path  %></li>
         <!-- <li><%# link_to "マイページ", mypages_show_path %></li> -->
 
         <li>

--- a/app/views/shared/_month_navigation.html.erb
+++ b/app/views/shared/_month_navigation.html.erb
@@ -1,3 +1,4 @@
+<!-- journals_controller / favorites_controller でメソッド定義 -->
 <div class="flex items-center justify-end gap-2 mb-4">
   <%= link_to "前月",
       path.call(year: prev_year, month: prev_month),

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -55,6 +55,9 @@ ja:
       next: "次へ"
       last: "最後"
       truncate: "..."
+  favorites:
+    index:
+      title: 保存した表現
   pages:
     privacy:
       title: "プライバシーポリシー"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   resource :mypage, only: [ :show ]
   resource :line_connection, only: [ :show, :create, :destroy ]
   # mistake_idを渡して、current_userのお気に入りから探して消す
-  resources :favorites, only: [ :create ] do
+  resources :favorites, only: [ :create, :index ] do
     delete :destroy, on: :collection
   end
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
お気に入り登録した表現を一覧で確認できるページを追加しました。

## 変更内容
- 保存した表現一覧ページを追加
   - ログイン中ユーザーが「保存」した `Mistake` を取得

- 「保存した表現」ページに以下を表示
    - 日付 / 学んだ表現 / 意味 / 添削前の文章 / 添削後の文章 / 似た表現・言い回し / 元の日記詳細へのリンク 

 - ヘッダーに「保存した表現」への導線を追加
 
## 確認方法
  - [ ] ログイン後、ヘッダーの「保存した表現」から `/favorites` に遷移できる
  - [ ] お気に入り登録した表現が一覧に表示される
  - [ ] 表現カードを開くと詳細内容が表示される
  - [ ] 「この日記を見る」から該当の日記詳細へ遷移できる
  - [ ] 保存した表現がない場合、空状態メッセージが表示される
  - [ ] 11件以上ある場合、ページネーションが表示される

## 関連Issue
closes #218