### PR TITLE
feat:1日のAI利用回数制限を追加

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -41,6 +41,11 @@ class JournalsController < ApplicationController
   end
 
   def create
+    if current_user.ai_usage_limit_reached?
+      redirect_to journals_path, alert: "本日のAI利用上限に達しました。明日またご利用ください。"
+      return
+    end
+
     @journal = current_user.journals.new(journal_params)
     if @journal.invalid?
       flash.now[:alert] =
@@ -125,6 +130,8 @@ class JournalsController < ApplicationController
         #   )
         # end
 
+        # AIの利用履歴を記録
+        current_user.record_ai_usage!
         redirect_to @journal, notice: "添削が完了しました！"
       else
         # DB保存に失敗したとき

--- a/app/models/ai_usage_log.rb
+++ b/app/models/ai_usage_log.rb
@@ -1,0 +1,4 @@
+class AiUsageLog < ApplicationRecord
+  belongs_to :user
+  validates :used_on, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,12 +71,17 @@ class User < ApplicationRecord
   end
 
 
+  def ai_usage_limit_exempt?
+    ENV.fetch("AI_LIMIT_EXEMPT_EMAILS", "")
+    .split(",")
+  end
 
   def ai_usage_count_today
     ai_usage_logs.where(used_on: Date.current).count
   end
 
   def ai_usage_limit_reached?
+    return false if ai_usage_limit_exempt?
     ai_usage_count_today >= DAILY_AI_LIMIT
   end
   # AIの利用履歴を記録

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  DAILY_AI_LIMIT = 5
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   has_many :journals, dependent: :destroy
@@ -9,6 +10,7 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   # お気に入りしたmistakes一覧(user.favoritesを経由して、favoriteに紐づくmistake)
   has_many :favorite_mistakes, through: :favorites, source: :mistake
+  has_many :ai_usage_logs, dependent: :destroy
 
   devise :database_authenticatable,
          :registerable,
@@ -66,5 +68,19 @@ class User < ApplicationRecord
 
   def favorite?(mistake)
     favorite_mistakes.exists?(mistake.id)
+  end
+
+
+
+  def ai_usage_count_today
+    ai_usage_logs.where(used_on: Date.current).count
+  end
+
+  def ai_usage_limit_reached?
+    ai_usage_count_today >= DAILY_AI_LIMIT
+  end
+  # AIの利用履歴を記録
+  def record_ai_usage!
+    ai_usage_logs.create!(used_on: Date.current)
   end
 end

--- a/db/migrate/20260627082904_create_ai_usage_logs.rb
+++ b/db/migrate/20260627082904_create_ai_usage_logs.rb
@@ -1,0 +1,11 @@
+class CreateAiUsageLogs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :ai_usage_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :used_on
+
+      t.timestamps
+    end
+    add_index :ai_usage_logs, [ :user_id, :used_on ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_25_070231) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_27_082904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_070231) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "ai_usage_logs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.date "used_on"
+    t.bigint "user_id", null: false
+    t.index ["user_id", "used_on"], name: "index_ai_usage_logs_on_user_id_and_used_on"
+    t.index ["user_id"], name: "index_ai_usage_logs_on_user_id"
   end
 
   create_table "favorites", force: :cascade do |t|
@@ -121,6 +130,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_25_070231) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "ai_usage_logs", "users"
   add_foreign_key "favorites", "mistakes"
   add_foreign_key "favorites", "users"
   add_foreign_key "journal_corrections", "journals"

--- a/spec/factories/ai_usage_logs.rb
+++ b/spec/factories/ai_usage_logs.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :ai_usage_log do
+    user { nil }
+    used_on { "2026-06-27" }
+  end
+end

--- a/spec/models/ai_usage_log_spec.rb
+++ b/spec/models/ai_usage_log_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AiUsageLog, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
日記のAI添削の1日利用回数制限を1ユーザーにつき5回までに制限しました。

## 変更内容
- AiUsageLogモデルを追加（AI利用履歴を保存）
- AI添削が完了したタイミングで、AI利用回数を1回カウント（記録）するようにしました。
- 日記作成時に、当日のAI利用回数を確認し、上限に達している場合は日記一覧画面にリダイレクトするようにしました。
- Userモデルに、AI利用回数の集計・上限判定・利用履歴記録用のメソッドを追加しました。

## 関連Issue
closes #223 