### PR TITLE
feat:音声読み上げ機能を追加

### DIFF
--- a/app/javascript/controllers/speech_controller.js
+++ b/app/javascript/controllers/speech_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["text", "rate"]
+
+speak() {
+  if(!("speechSynthesis" in window)) {
+    alert("このブラウザは音声読み上げに対応していません。")
+    return
+  }
+  
+  const text = this.textTarget.textContent.trim()
+  const rate = Number(this.rateTarget.value)
+
+  const utterance = new SpeechSynthesisUtterance(text)
+  utterance.lang = "en-US"
+  utterance.rate = rate
+  utterance.pitch = 1
+
+  speechSynthesis.cancel()
+  speechSynthesis.speak(utterance)
+}
+
+stop() {
+  if ("speechSynthesis" in window) {
+    speechSynthesis.cancel()
+  }
+ }
+}

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -8,8 +8,7 @@
 
       <div class="card bg-base-100 shadow mb-4 p-4 sm:p-5 md:p-6">
         <div class="text-sm sm:text-base">
-          <p class="leading-7 pb-3">Capture Your Day（以下「本アプリ」）は、ユーザーに安心して利用いただけるよう、以下の方針に基づい
-  て個人情報を管理します。</p>
+          <p class="leading-7 pb-3">Capture Your Day（以下「本アプリ」）は、以下の方針に基づいて個人情報を管理します。</p>
         
           <section class="space-y-3 border-t border-b border-base-300 py-6">
             <h2 class="font-semibold text-base sm:text-xl ">1. 取得する情報</h2>
@@ -110,7 +109,7 @@
             </p>
           </section>
 
-          <p class="text-base-content/70 pt-6">最終更新日：2026年6月22日</p>
+          <p class="text-base-content/70 pt-6">最終更新日：2026年6月30日</p>
 
         </div>
       </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -91,7 +91,7 @@
         </p>
       </section>
 
-      <p class="text-base-content/70 pt-6">最終更新日：2026年6月22日</p>
+      <p class="text-base-content/70 pt-6">最終更新日：2026年6月30日</p>
       
       </div>
     </div>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -20,7 +20,7 @@
             <button type="button"
                     class="btn btn-sm border-primary text-primary hover:bg-primary hover:text-white"
                     data-action="speech#speak">
-            🔊 英語を聞く
+            🔊 英文を聞く
             </button>
 
             <button type="button"

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -5,7 +5,32 @@
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
       </div>
-          <p class="text-sm sm:text-base px-5 p-4 whitespace-pre-line"><%= @journal_correction.rewritten_text %></p>
+        <!-- 音声読み上げ -->
+        <div data-controller="speech">
+          <p data-speech-target="text"
+             class="text-sm sm:text-base px-5 py-2 whitespace-pre-line">
+             <%= @journal_correction.rewritten_text %>
+          </p>
+          <div class="px-5 pb-3 flex items-center gap-2">
+            <select data-speech-target="rate" class="select select-bordered select-sm">
+              <option value="0.75">速度：ゆっくり</option>
+              <option value="1" selected>速度：標準</option>
+              <option value="1.25">速度：速め</option>
+            </select>
+            <button type="button"
+                    class="btn btn-sm border-primary text-primary hover:bg-primary hover:text-white"
+                    data-action="speech#speak">
+            🔊 英語を聞く
+            </button>
+
+            <button type="button"
+                    class="btn btn-sm border-primary text-primary hover:bg-primary hover:text-white"
+                    data-action="speech#stop">
+            停止
+
+            </button>
+          </div>
+        </div>
     </div>
     <% if @journal_correction.mistakes.present? %>
       <div class="flex justify-between items-center mb-3">


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
日記詳細ページに、添削後の英文読み上げ機能を追加しました。

## 変更内容
- 日記詳細ページに、添削後の英文の音声読み上げボタンを追加
- 読み上げ速度を「ゆっくり/標準/速め」から選択できるように追加
- 読み上げ停止ボタンの追加

## 確認方法
- 「英文を聞く」のボタンを押下すると、添削後の英文が読み上げられる
- 「停止」ボタンを押下すると、音声が停止される
- 読み上げ速度を変更すると、速度が変わる

## 補足
- 外部APIは使わず、ブラウザ標準の `SpeechSynthesis` を使用
 - 読み上げ言語は、添削文の方針に合わせて `en-US` 固定

## 関連Issue
closes #229 