### PR TITLE
fix:日記詳細の表現保存のボタンのレイアウト修正

### DIFF
--- a/app/views/mistakes/_favorite.html.erb
+++ b/app/views/mistakes/_favorite.html.erb
@@ -3,6 +3,6 @@
 <%= link_to favorites_path(mistake_id: mistake.id), 
     id: "favorite-button-for-mistake-#{mistake.id}",
     data: { turbo_method: :post },
-    class: "btn btn-ghost btn-sm text-primary border border-primary hover:bg-primary hover:text-white" do %>
-<span class="text-base">☆ 保存</span>
+    class: "btn btn-ghost btn-sm text-primary border border-primary hover:bg-primary hover:text-white shrink-0 whitespace-nowrap self-end sm:self-start" do %>
+<span class="text-base ">☆ 保存</span>
 <% end %>

--- a/app/views/mistakes/_unfavorite.html.erb
+++ b/app/views/mistakes/_unfavorite.html.erb
@@ -2,6 +2,6 @@
 <%= link_to favorites_path(mistake_id: mistake.id), 
     id:"unfavorite-button-for-mistake-#{mistake.id}", 
     data: { turbo_method: :delete },
-    class: "btn btn-primary btn-sm text-white" do %>
+    class: "btn btn-primary btn-sm text-white shrink-0 whitespace-nowrap self-end sm:self-start" do %>
   <span class="text-base">保存済み</span>
 <% end %>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -27,7 +27,6 @@
                     class="btn btn-sm border-primary text-primary hover:bg-primary hover:text-white"
                     data-action="speech#stop">
             停止
-
             </button>
           </div>
         </div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
スマホで日記詳細の表現の保存ボタンの表示が崩れていることがあったので、保存ボタンのレイアウトを修正をしました。

## 変更内容
 - 保存ボタンが縮まないように `shrink-0` を追加
- ボタン内の文言が改行されないように `whitespace-nowrap` を追加

## 確認方法
-スマホで日記詳細を表示した際に「☆保存」「保存済み」ボタンの表示が崩れていないこと 

## 関連Issue
closes #