### PR TITLE
fix:音声読み上げボタン設置

### DIFF
--- a/app/assets/images/icons/play.svg
+++ b/app/assets/images/icons/play.svg
@@ -1,0 +1,14 @@
+<!--?xml version="1.0" encoding="utf-8"?-->
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512" style="width: 48px; height: 48px; opacity: 1;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4B4B4B;}
+</style>
+<g>
+	<path class="st0" d="M256,0C114.625,0,0,114.625,0,256c0,141.374,114.625,256,256,256c141.374,0,256-114.626,256-256
+		C512,114.625,397.374,0,256,0z M351.062,258.898l-144,85.945c-1.031,0.626-2.344,0.657-3.406,0.031
+		c-1.031-0.594-1.687-1.702-1.687-2.937v-85.946v-85.946c0-1.218,0.656-2.343,1.687-2.938c1.062-0.609,2.375-0.578,3.406,0.031
+		l144,85.962c1.031,0.586,1.641,1.718,1.641,2.89C352.703,257.187,352.094,258.297,351.062,258.898z"></path>
+</g>
+</svg>

--- a/app/assets/images/icons/stop.svg
+++ b/app/assets/images/icons/stop.svg
@@ -1,0 +1,15 @@
+<!--?xml version="1.0" encoding="utf-8"?-->
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512" style="width: 48px; height: 48px; opacity: 1;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4B4B4B;}
+</style>
+<g>
+	<path class="st0" d="M256.002,0c-141.16,0-256,114.836-256,255.996c0,141.16,114.84,256.004,256,256.004
+		c141.161,0,255.996-114.843,255.996-256.004C511.998,114.836,397.163,0,256.002,0z M256.002,466.046
+		c-116,0-210.049-94.046-210.049-210.049c0-115.997,94.049-210.049,210.049-210.049c115.997,0,210.049,94.052,210.049,210.049
+		C466.051,372,371.999,466.046,256.002,466.046z" style="fill: rgb(75, 75, 75);"></path>
+	<rect x="196.925" y="196.922" class="st0" width="118.151" height="118.155" style="fill: rgb(75, 75, 75);"></rect>
+</g>
+</svg>

--- a/app/javascript/controllers/speech_controller.js
+++ b/app/javascript/controllers/speech_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["text", "rate"]
+  static targets = ["text", "rate", "playButton", "stopButton"]
 
 speak() {
   if(!("speechSynthesis" in window)) {
@@ -17,13 +17,38 @@ speak() {
   utterance.rate = rate
   utterance.pitch = 1
 
+  utterance.onend = () => {
+    this.showPlayButton()
+  }
+
+  utterance.onerror = () => {
+    this.showPlayButton()
+  }
+
   speechSynthesis.cancel()
   speechSynthesis.speak(utterance)
-}
+  this.showStopButton()
+ }
 
 stop() {
   if ("speechSynthesis" in window) {
     speechSynthesis.cancel()
   }
+  this.showPlayButton()
+ }
+
+ disconnect() {
+  if("speechSynthesis" in window)
+    speechSynthesis.cancel()
+ }
+
+showStopButton() {
+  this.playButtonTarget.classList.add("hidden")
+  this.stopButtonTarget.classList.remove("hidden")
+ }
+
+showPlayButton() {
+  this.stopButtonTarget.classList.add("hidden")
+  this.playButtonTarget.classList.remove("hidden")
  }
 }

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -1,12 +1,34 @@
-    <div class="border border-base-300 bg-base-100 rounded-2xl mb-4">
+    <div data-controller="speech" class="border border-base-300 bg-base-100 rounded-2xl mb-4">
       <div class="flex items-center gap-2 bg-secondary border-b border-forest-200 px-4 ">
         <h2 class="font-semibold text-sm sm:text-base py-2 text-primary">添削後の文章</h2>
+        
         <span class="badge badge-success text-white px-3 py-3">
         添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
         </span>
+        
+        <div class="ml-auto flex items-center gap-2">
+          <select data-speech-target="rate" class="select select-bordered select-sm">
+            <option value="0.75">速度：ゆっくり</option>
+            <option value="1" selected>速度：標準</option>
+            <option value="1.25">速度：速め</option>
+          </select>
+
+          <button type="button"
+                  class="btn btn-sm btn-circle hover:bg-primary/50 hover:text-white"
+                  data-speech-target="playButton"
+                  data-action="speech#speak">
+            <%= image_tag "icons/play.svg", alt:"", class: "w-5 h-5" %>
+          </button>
+          <button type="button"
+                  class="btn btn-sm btn-circle hover:bg-primary/50 hover:text-white"
+                  data-speech-target="stopButton"
+                  data-action="speech#stop">
+            <%= image_tag "icons/stop.svg", alt:"", class: "w-5 h-5" %>
+          </button>
+        </div>
       </div>
         <!-- 音声読み上げ -->
-        <div data-controller="speech">
+        <!--<div data-controller="speech">
           <p data-speech-target="text"
              class="text-sm sm:text-base px-5 py-2 whitespace-pre-line">
              <%= @journal_correction.rewritten_text %>
@@ -30,6 +52,8 @@
             </button>
           </div>
         </div>
+    </div> -->
+        <p data-speech-target="text" class="text-sm sm:text-base px-5 py-4 whitespace-pre-line" ><%= @journal_correction.rewritten_text %></p>
     </div>
     <% if @journal_correction.mistakes.present? %>
       <div class="flex justify-between items-center mb-3">


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
日記詳細ページの音声読み上げボタンを、添削後の文章カード内のヘッダー部分に移動し、テキストボタンからアイコンボタンに変更しました。

## 変更内容
- 音声読み上げボタンを、添削後の文章本文下から添削トーン横に移動
- 「英文を聞く」「停止」のテキストボタンから、アイコンボタンに変更
- 再生中は再生アイコンを非表示にし、停止アイコンを表示するように変更

## 確認方法
- 日記詳細ページで、添削トーン横に速度選択・再生アイコンが表示されること
- 再生アイコンを押下したら、英文が読み上げられること
- 再生アイコンを押下したら、停止アイコンが表示されること
- 読み上げ完了後に、再生アイコンに戻ること

## 関連Issue
closes #