### PR TITLE
feat:Webプッシュリマインダー通知画面作成

### DIFF
--- a/app/controllers/notification_settings_controller.rb
+++ b/app/controllers/notification_settings_controller.rb
@@ -1,0 +1,23 @@
+class NotificationSettingsController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @notification_setting = current_user.notification_setting || current_user.create_notification_setting!
+  end
+
+  def update
+    @notification_setting = current_user.notification_setting || current_user.build_notification_setting
+
+    if @notification_setting.update(notification_setting_params)
+      redirect_to notification_setting_path, notice: "リマインダー通知設定を更新しました。"
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def notification_setting_params
+    params.require(:notification_setting).permit(:reminder_enabled, :notification_time)
+  end
+end

--- a/app/helpers/notification_settings_helper.rb
+++ b/app/helpers/notification_settings_helper.rb
@@ -1,0 +1,2 @@
+module NotificationSettingsHelper
+end

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -3,7 +3,7 @@
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
     <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-2xl text-center font-cream-500 mb-4 sm:mb-6">
-    日記一覧 (<%= @current_month.strftime("%Y年%-m月") %>)
+    <%=t('.title') %> (<%= @current_month.strftime("%Y年%-m月") %>)
     </h1>
     <%= render "shared/month_navigation",
         current_month: @current_month,

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
-  <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
+  <div class="max-w-2xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -31,9 +31,9 @@
         <h2 class="card-title">LINE通知設定</h2>
       <% end %>
 
-      <div class="card bg-base-100 shadow mb-4 p-3">
+      <%= link_to notification_setting_path, class:"card bg-base-100 shadow mb-4 p-3 hover:bg-base-300 transition" do%>
         <h2 class="card-title">リマインダー通知設定</h2>
-      </div>
+      <% end %>
 
       <%= link_to terms_path, class:"card bg-base-100 shadow mb-4 p-3 hover:bg-base-300 transition" do %>
         <h2 class="card-title">利用規約</h2>

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -1,0 +1,30 @@
+<!-- Rails側で通知ON/OFFと通知時間を保存する -->
+<% content_for(:title, t('.title', default: APP_NAME)) %>
+<div class="flex-grow px-4 sm:px-6 md;px-10">
+  <div class="max-w-2xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
+    <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-center font-cream-500 mb-4 sm:mb-6">
+      <%= t('.title') %>
+    </h1>
+    <p class="mb-6 text-base-content text-center sm:text-md md:text-lg">
+        設定した時間に、リマインダーを通知します。
+      </p>
+    <div class="card bg-base-100 shadow p-5">
+      <%= form_with model: @notification_setting, url: notification_setting_path, method: :patch do |f| %>
+        <div class="flex items-center gap-3 mb-4 bg-base-200 px-4 py-3">
+          <%= f.label :reminder_enabled, "リマインダー通知を受け取る", class:"font-medium" %>
+          <%= f.check_box :reminder_enabled, class:"toggle toggle-primary" %>
+        </div>
+
+        <div class="flex items-center gap-3 mb-4 bg-base-200 px-4 py-3">
+          <%= f.label :notification_time, "通知時間", class:"font-medium" %>
+          <%= f.time_field :notification_time, class: "input input-bordered" %>
+        </div>
+
+        <div class="flex justify-end gap-2 mt-6">
+          <%= link_to "戻る", mypage_path, class: "btn btn-outline border-primary text-primary hover:bg-primary hover:border-primary" %>
+          <%= f.submit "保存する", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -63,6 +63,8 @@ ja:
       title: "プライバシーポリシー"
     terms:
       title: "利用規約"
-  
+  notification_settings:
+    show:
+      title: "リマインダー通知設定"
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
   resources :journal_corrections, only: [ :index, :show ]
   resource :mypage, only: [ :show ]
   resource :line_connection, only: [ :show, :create, :destroy ]
+  resource :notification_setting, only: [ :show, :update ]
   # mistake_idを渡して、current_userのお気に入りから探して消す
   resources :favorites, only: [ :create, :index ] do
     delete :destroy, on: :collection

--- a/spec/helpers/notification_settings_helper_spec.rb
+++ b/spec/helpers/notification_settings_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the NotificationSettingsHelper. For example:
+#
+# describe NotificationSettingsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe NotificationSettingsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/notification_settings_spec.rb
+++ b/spec/requests/notification_settings_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "NotificationSettings", type: :request do
+  describe "GET /show" do
+    it "returns http success" do
+      get "/notification_setting/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/views/notification_settings/show.html.tailwindcss_spec.rb
+++ b/spec/views/notification_settings/show.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "notification_settings/show.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
Webプッシュ通知実装の前段階として、リマインダー通知のON・OFF、通知時間を設定する画面を作成しました。

## 変更内容
- リマインダー通知設定画面を追加
- NotificationSettingのreminder_enabled/ notification_timeを更新できるようにした

## 確認方法
- マイページからリマインダー通知設定画面へ遷移できる
- 通知ON・OFFを保存できる
- 通知時間を保存できる
- 保存後マイページ画面に戻る

## 関連Issue
closes #237