### PR TITLE
feat:Webプッシュ購読情報の保存機能を追加

### DIFF
--- a/app/controllers/web_push_subscriptions_controller.rb
+++ b/app/controllers/web_push_subscriptions_controller.rb
@@ -1,0 +1,14 @@
+class WebPushSubscriptionsController < ApplicationController
+  before_action :authenticate_user!
+  def create
+    subscription = WebPushSubscription.find_or_initialize_by(endpoint: params[:endpoint])
+
+    subscription.update!(
+      user: current_user,
+      p256dh: params[:p256dh],
+      auth: params[:auth]
+    )
+
+    head :ok
+  end
+end

--- a/app/javascript/api/push_subscription.js
+++ b/app/javascript/api/push_subscription.js
@@ -1,0 +1,49 @@
+export class PushSubscriptionService {
+  constructor(vapidPublicKey){
+    this.vapidPublicKey = vapidPublicKey
+  }
+
+  async getRegistration() {
+    await navigator.serviceWorker.register("/service-worker.js")
+    return navigator.serviceWorker.ready
+  }
+
+  async getSubscription() {
+    const registration = await this.getRegistration()
+    return registration.pushManager.getSubscription()
+  }
+
+  async createSubscription() {
+    const registration = await this.getRegistration()
+
+    return registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: Uint8Array.fromBase64(this.vapidPublicKey,
+        alphabet: "base64url"
+      })
+    })
+  }
+
+  async saveSubscription(subscription) {
+    const { endpoint, keys } = subscription.toJSON()
+    if(!endpoint || !keys?.p256dh || !keys?.auth) return false
+    const response = await fetch("/web_push_subscriptions", {
+      method: "POST",
+      headers: this.csrfHeaders(),
+      body: JSON.stringify({
+        endpoint,
+        p256dh: keys.p256dh,
+        auth: keys.auth
+      })
+    })
+    return response.ok
+  }
+
+  csrfHeaders() {
+    return {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      
+    }
+  }
+}

--- a/app/javascript/controllers/push_notification_controller.js
+++ b/app/javascript/controllers/push_notification_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus"
+import { PushSubscriptionService } from "api/push_subscription"
+
+export default class extends Controller {
+  static values = {
+    vapidPublicKey: String
+  }
+
+  connect() {
+    this.service = new PushSubscriptionService(this.vapidPublicKeyValue)
+  }
+
+  async subscribe() {
+    if (!("serviceWorker" in navigator)) return
+    if (!("PushManager" in window)) return
+    if (!("Notification" in window)) return
+
+    const permission = await Notification.requestPermission()
+    if (permission !== "granted") return
+
+    let subscription = await this.service.getSubscription()
+
+    if (!subscription) {
+      subscription = await this.service.createSubscription()
+    }
+
+    await this.service.saveSubscription(subscription)
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   # お気に入りしたmistakes一覧(user.favoritesを経由して、favoriteに紐づくmistake)
   has_many :favorite_mistakes, through: :favorites, source: :mistake
   has_many :ai_usage_logs, dependent: :destroy
+  has_many :web_push_subscriptions, dependent: :destroy
 
   devise :database_authenticatable,
          :registerable,

--- a/app/models/web_push_subscription.rb
+++ b/app/models/web_push_subscription.rb
@@ -1,0 +1,7 @@
+class WebPushSubscription < ApplicationRecord
+  belongs_to :user
+
+  validates :endpoint, presence: true, uniqueness: true
+  validates :p256dh, presence: true
+  validates :auth, presence: true
+end

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -3,12 +3,23 @@
 <div class="flex-grow px-4 sm:px-6 md;px-10">
   <div class="max-w-2xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-center font-cream-500 mb-4 sm:mb-6">
-      <%= t('.title') %>
+      <%= t('.title') %> （実装途中です）
     </h1>
     <p class="mb-6 text-base-content text-center sm:text-md md:text-lg">
         設定した時間に、リマインダーを通知します。
       </p>
-    <div class="card bg-base-100 shadow p-5">
+    <div class="card bg-base-100 shadow mb-2 px-4">
+      <div class="mt-6 border-base-300 mb-3"
+           data-controller="push-notification"
+           data-push-notification-vapid-public-key-value="<%= Rails.application.credentials.dig(:webpush, :vapid_public_key) %>" >
+
+      <button type="button"
+              class="btn btn-secondary w-full"
+              data-action="click->push-notification#subscribe">
+      このブラウザで通知を有効にする
+      </button>
+      </div>
+
       <%= form_with model: @notification_setting, url: notification_setting_path, method: :patch do |f| %>
         <div class="flex items-center gap-3 mb-4 bg-base-200 px-4 py-3">
           <%= f.label :reminder_enabled, "リマインダー通知を受け取る", class:"font-medium" %>
@@ -20,11 +31,13 @@
           <%= f.time_field :notification_time, class: "input input-bordered" %>
         </div>
 
-        <div class="flex justify-end gap-2 mt-6">
+        <div class="flex justify-end gap-2 mt-6 mb-3">
           <%= link_to "戻る", mypage_path, class: "btn btn-outline border-primary text-primary hover:bg-primary hover:border-primary" %>
           <%= f.submit "保存する", class: "btn btn-primary" %>
         </div>
       <% end %>
+
+
     </div>
   </div>
 </div>

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -24,3 +24,10 @@
 //     })
 //   )
 // })
+self.addEventListener("push", async (event) => {
+  const data = event.data ? await event.data.json() : { title: "通知", options: {} } 
+
+  event.waitUntil(
+    self.ServiceWorkerRegistration.showNotification(data.title, data.options || {})
+  )
+})

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "cally" # @0.9.2
+pin_all_from "app/javascript/api", under: "api"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,8 @@ Rails.application.routes.draw do
   resource :mypage, only: [ :show ]
   resource :line_connection, only: [ :show, :create, :destroy ]
   resource :notification_setting, only: [ :show, :update ]
-  # mistake_idを渡して、current_userのお気に入りから探して消す
+  resources :web_push_subscriptions, only: [ :create ]
+  # mistake_idを渡して、current_userのfavoriteを作成する
   resources :favorites, only: [ :create, :index ] do
     delete :destroy, on: :collection
   end

--- a/db/migrate/20260704094008_create_web_push_subscriptions.rb
+++ b/db/migrate/20260704094008_create_web_push_subscriptions.rb
@@ -1,0 +1,14 @@
+class CreateWebPushSubscriptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :web_push_subscriptions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.text :endpoint, null: false
+      t.string :p256dh, null: false
+      t.string :auth, null: false
+
+      t.timestamps
+    end
+
+    add_index :web_push_subscriptions, :endpoint, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_27_082904) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_04_094008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -128,6 +128,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_082904) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "web_push_subscriptions", force: :cascade do |t|
+    t.string "auth", null: false
+    t.datetime "created_at", null: false
+    t.text "endpoint", null: false
+    t.string "p256dh", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["endpoint"], name: "index_web_push_subscriptions_on_endpoint", unique: true
+    t.index ["user_id"], name: "index_web_push_subscriptions_on_user_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "ai_usage_logs", "users"
@@ -140,4 +151,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_27_082904) do
   add_foreign_key "mistakes", "journals"
   add_foreign_key "mistakes", "users"
   add_foreign_key "notification_settings", "users"
+  add_foreign_key "web_push_subscriptions", "users"
 end

--- a/spec/factories/web_push_subscriptions.rb
+++ b/spec/factories/web_push_subscriptions.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :web_push_subscription do
+    user { nil }
+    endpoint { "MyText" }
+    p256dh { "MyString" }
+    auth { "MyString" }
+  end
+end

--- a/spec/models/web_push_subscription_spec.rb
+++ b/spec/models/web_push_subscription_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WebPushSubscription, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/web_push_subscriptions_spec.rb
+++ b/spec/requests/web_push_subscriptions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "WebPushSubscriptions", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/web_push_subscriptions/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
Webプッシュ通知の配信準備として、ブラウザの Push Subscription 情報を保存できるようにしました。

## 変更内容
  - `WebPushSubscription` モデルを追加
  - ログイン中ユーザーに紐づく Web Push 購読情報を保存
  - 通知設定画面に「このブラウザで通知を有効にする」ボタンを追加
  - Stimulus から通知許可・Push 購読作成・購読情報保存を実行
  - Service Worker に push イベント受信処理を追加

## 補足
今回のPRでは、通知の手動送信・定時送信は未実装です

## 関連Issue
closes #130 