### PR TITLE
style:添削表示の文字サイズを調整

### DIFF
--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -22,7 +22,7 @@
     </div>
       <div class="md:hidden collapse collapse-arrow border border-base-300 bg-base-100 rounded-2xl overflow-hidden mb-4">
         <input type="checkbox" />
-          <h2 class="collapse-title font-semibold pr-10 bg-error/10 text-error">元の文章を表示</h2>
+          <h2 class="collapse-title font-semibold text-sm sm:text-base pr-10 bg-error/10 text-error">元の文章を表示</h2>
 
           <div class="collapse-content">
             <p class="px-2 py-2 whitespace-pre-line"><%= @journal_correction&.original_text %></p>

--- a/app/views/shared/_mistakes_list.html.erb
+++ b/app/views/shared/_mistakes_list.html.erb
@@ -55,7 +55,7 @@
           </div>
         </div>
     </div> -->
-        <p data-speech-target="text" class="text-sm sm:text-base px-5 py-4 whitespace-pre-line" ><%= @journal_correction.rewritten_text %></p>
+        <p data-speech-target="text" class="px-5 py-4 whitespace-pre-line" ><%= @journal_correction.rewritten_text %></p>
     </div>
     <% if @journal_correction.mistakes.present? %>
       <div class="flex justify-between items-center mb-3">
@@ -92,15 +92,15 @@
                 <%# ボディ %>
                 <div class="px-4 py-3">
                   <p class="text-base-content/70 mb-1 text-sm sm:text-base">今回の添削</p>
-                  <p class="mx-2 text-sm sm:text-base bg-error/10 px-3 py-2 text-error mb-2 rounded-xl">  
+                  <p class="mx-2 bg-error/10 px-3 py-2 text-error mb-2 rounded-xl">  
                   <%= mistake.original_text %></p>
-                  <p class="mx-2 text-sm sm:text-base  bg-base-200  text-primary font-semibold border-forest-200 rounded-xl px-3 py-2">
+                  <p class="mx-2 bg-base-200 text-primary font-semibold border-forest-200 rounded-xl px-3 py-2">
                   <%= mistake.corrected_text %></p>
 
                 <%# ポイント %>
                 <% if mistake.explanation.present? %>
                   <p class="text-base-content/70 mt-2 text-sm sm:text-base">ポイント</p>
-                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content sm:text-base">
+                  <div class="mx-2 bg-base-200 rounded-xl px-3 py-2 text-base-content text-sm sm:text-base">
                     <%= mistake.explanation %>
                   </div>
                 <% end %>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
添削結果表示まわりの文字サイズを調整しました。

## 変更内容
  - スマホ表示の「元の文章を表示」の見出しに `text-sm sm:text-base` を追加
  - 添削後文章・添削前文章・添削後表現の不要な文字サイズ指定を整理

## 確認方法
  - [ ] 日記詳細ページを表示する
  - [ ] スマホ幅で「元の文章を表示」の見出しサイズを確認する
  - [ ]  添削結果、今回の添削、ポイント欄の文字サイズを確認する

## 関連Issue
closes #