### PR TITLE
feat:Webプッシュリマインダー送信タスクを追加

### DIFF
--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -1,7 +1,5 @@
 class NotificationSetting < ApplicationRecord
   belongs_to :user
 
-  enum :scene_type, { light: 0, dark: 1 }
-
   validates :notification_time, presence: true, if: :reminder_enabled?
 end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -2,4 +2,6 @@ class NotificationSetting < ApplicationRecord
   belongs_to :user
 
   enum :scene_type, { light: 0, dark: 1 }
+
+  validates :notification_time, presence: true, if: :reminder_enabled?
 end

--- a/app/services/web_push_reminder_broadcaster.rb
+++ b/app/services/web_push_reminder_broadcaster.rb
@@ -1,0 +1,51 @@
+# 通知対象ユーザーを探し、Webプッシュ通知を送信する
+class WebPushReminderBroadcaster
+  def initialize(now: Time.current)
+    @now = now
+  end
+
+  def call
+    target_settings.find_each do |setting|
+      deliver_to(setting)
+    end
+  end
+
+  private
+
+  attr_reader :now
+
+  def target_settings
+    NotificationSetting
+      .includes(user: :web_push_subscriptions)
+      .where(reminder_enabled: true)
+      .where(notification_time: target_time)
+      .where("last_web_push_reminded_on IS NULL OR last_web_push_reminded_on != ?", today)
+  end
+
+  def deliver_to(setting)
+    subscriptions = setting.user.web_push_subscriptions
+    return if subscriptions.empty?
+
+    subscriptions.find_each do |subscription|
+      WebPushNotificationSender.new(subscription).call(
+        title: "英語ジャーナリングの時間です",
+        body: "今日の出来事を書いてみましょう",
+        path: "/journals/new"
+      )
+    end
+
+    setting.update!(last_web_push_reminded_on: today)
+  rescue => e
+    Rails.logger.error(
+      "[WebPushReminderBroadcaster] user_id=#{setting.user_id} #{e.class}: #{e.message}"
+    )
+  end
+
+  def target_time
+    Time.zone.parse(now.strftime("%H:%M"))
+  end
+
+  def today
+    now.to_date
+  end
+end

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -29,7 +29,9 @@
 
         <div class="flex items-center gap-3 mb-4 bg-base-200 px-4 py-3">
           <%= f.label :notification_time, "通知時間", class:"font-medium" %>
-          <%= f.time_field :notification_time, class: "input input-bordered" %>
+          <%= f.time_select :notification_time,
+              { minute_step: 30, ignore_date: true },
+              { class: "select select-bordered" } %>
         </div>
 
         <div class="flex justify-end gap-2 mt-6 mb-3">

--- a/db/migrate/20260713061035_add_last_web_push_reminder_on_to_notification_settings.rb
+++ b/db/migrate/20260713061035_add_last_web_push_reminder_on_to_notification_settings.rb
@@ -1,0 +1,5 @@
+class AddLastWebPushReminderOnToNotificationSettings < ActiveRecord::Migration[8.1]
+  def change
+    add_column :notification_settings, :last_web_push_reminded_on, :date
+  end
+end

--- a/db/migrate/20260713080921_remove_scene_type_from_notification_settings.rb
+++ b/db/migrate/20260713080921_remove_scene_type_from_notification_settings.rb
@@ -1,0 +1,5 @@
+class RemoveSceneTypeFromNotificationSettings < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :notification_settings, :scene_type, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_04_094008) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_13_080921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -102,9 +102,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_04_094008) do
 
   create_table "notification_settings", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.date "last_web_push_reminded_on"
     t.time "notification_time"
     t.boolean "reminder_enabled", default: false
-    t.integer "scene_type", default: 0
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_notification_settings_on_user_id"

--- a/lib/tasks/web_push_reminders.rake
+++ b/lib/tasks/web_push_reminders.rake
@@ -1,0 +1,10 @@
+# namespace:Rake task の名前をグループ分け
+namespace :web_push_reminders do
+  # タスクの説明文
+  desc "Send web push reminder notifications"
+
+  # タスク名
+  task send: :environment do
+    WebPushReminderBroadcaster.new.call
+  end
+end

--- a/spec/factories/notification_settings.rb
+++ b/spec/factories/notification_settings.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :notification_setting do
+  user
+  reminder_enabled { false }
+  notification_time { "21:00" }
+  end
+end

--- a/spec/factories/web_push_subscriptions.rb
+++ b/spec/factories/web_push_subscriptions.rb
@@ -1,8 +1,10 @@
 FactoryBot.define do
   factory :web_push_subscription do
-    user { nil }
-    endpoint { "MyText" }
-    p256dh { "MyString" }
-    auth { "MyString" }
+    user
+    endpoint do
+      "https://example.com/push/#{SecureRandom.hex(8)}"
+    end
+    p256dh { "dummy_p256dh" }
+    auth { "dummy_auth" }
   end
 end

--- a/spec/services/web_push_reminder_broadcaster_spec.rb
+++ b/spec/services/web_push_reminder_broadcaster_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe WebPushReminderBroadcaster do
+  describe "#call" do
+    let(:now) do
+      Time.zone.local(2026, 7, 13, 21, 0, 0)
+    end
+
+    it "設定時刻が一致する通知ONのユーザーに送信する" do
+      user = create(:user)
+      setting = create(
+        :notification_setting,
+        user: user,
+        reminder_enabled: true,
+        notification_time: "21:00"
+      )
+      subscription = create(:web_push_subscription, user: user)
+      sender = instance_double(WebPushNotificationSender, call: true)
+
+      allow(WebPushNotificationSender)
+        .to receive(:new)
+        .with(subscription)
+        .and_return(sender)
+
+      described_class.new(now: now).call
+
+      expect(sender).to have_received(:call)
+      expect(setting.reload.last_web_push_reminded_on).to eq(now.to_date)
+    end
+
+    it "リマインダーOFFのユーザーには送信しない" do
+      user = create(:user)
+      create(
+        :notification_setting,
+        user: user,
+        reminder_enabled: false,
+        notification_time: "21:00"
+      )
+      create(:web_push_subscription, user: user)
+
+      allow(WebPushNotificationSender).to receive(:new)
+
+      described_class.new(now: now).call
+
+      expect(WebPushNotificationSender).not_to have_received(:new)
+    end
+  end
+end

--- a/test/fixtures/notification_settings.yml
+++ b/test/fixtures/notification_settings.yml
@@ -4,10 +4,8 @@ one:
   user: one
   reminder_enabled: false
   notification_time: 2026-04-07 20:14:51
-  scene_type: 1
 
 two:
   user: two
   reminder_enabled: false
   notification_time: 2026-04-07 20:14:51
-  scene_type: 1


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
リマインダの設定時刻になったユーザーにWebプッシュリマインダーを送信する処理を追加しました。

## 変更内容
- 通知時刻を30分単位で選択するように変更
- notification_settingsにlast_web_push_reminded_onを追加
- Webプッシュリマインダー送信用のWebPushReminderBroadcasterを追加
- web_push_reminders:send Rake taskを追加

## 関連Issue
closes #238