### PR TITLE
feat:Webプッシュリマインダーの定期実行を本番環境に設定

### DIFF
--- a/app/services/web_push_reminder_broadcaster.rb
+++ b/app/services/web_push_reminder_broadcaster.rb
@@ -19,7 +19,7 @@ class WebPushReminderBroadcaster
       .includes(user: :web_push_subscriptions)
       .where(reminder_enabled: true)
       .where(notification_time: target_time)
-      .where("last_web_push_reminded_on IS NULL OR last_web_push_reminded_on != ?", today)
+    #   .where("last_web_push_reminded_on IS NULL OR last_web_push_reminded_on != ?", today)
   end
 
   def deliver_to(setting)

--- a/app/views/notification_settings/show.html.erb
+++ b/app/views/notification_settings/show.html.erb
@@ -3,7 +3,7 @@
 <div class="flex-grow px-4 sm:px-6 md;px-10">
   <div class="max-w-2xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-center font-cream-500 mb-4 sm:mb-6">
-      <%= t('.title') %> （実装途中です）
+      <%= t('.title') %> 
     </h1>
     <p class="mb-6 text-base-content text-center sm:text-md md:text-lg">
         設定した時間に、リマインダーを通知します。

--- a/app/views/pwa/service-worker.js
+++ b/app/views/pwa/service-worker.js
@@ -4,29 +4,35 @@
 //   const { title, options } = await event.data.json()
 //   event.waitUntil(self.registration.showNotification(title, options))
 // })
-//
-// self.addEventListener("notificationclick", function(event) {
-//   event.notification.close()
-//   event.waitUntil(
-//     clients.matchAll({ type: "window" }).then((clientList) => {
-//       for (let i = 0; i < clientList.length; i++) {
-//         let client = clientList[i]
-//         let clientPath = (new URL(client.url)).pathname
-//
-//         if (clientPath == event.notification.data.path && "focus" in client) {
-//           return client.focus()
-//         }
-//       }
-//
-//       if (clients.openWindow) {
-//         return clients.openWindow(event.notification.data.path)
-//       }
-//     })
-//   )
-// })
+
+self.addEventListener("notificationclick", function(event) {
+  event.notification.close()
+
+  const path = event.notification.data?.path || "/"
+  event.waitUntil(
+    clients.matchAll({
+      type: "window",
+    includeUncontrolled: true 
+  }).then((clientList) => {
+    const Url = new URL(path, self.location.origin).href
+    const existingClient = clientList.find(
+      (client) => client.url === targetUrl
+    )
+
+    if (existingClient && "focus" in existingClient) {
+      return existingClient.focus()
+    }
+
+    if (clients.openWindow) {
+      return clients.openWindow(path)
+    }
+    })
+  )
+})
+
 // Push通知を受け取り、ブラウザ通知として表示する
-self.addEventListener("push", async (event) => {
-  const data = event.data ? await event.data.json() : { title: "通知", options: {} } 
+self.addEventListener("push", (event) => {
+  const data = event.data ? event.data.json() : { title: "通知", options: {} } 
 
   event.waitUntil(
     self.registration.showNotification(data.title, data.options || {})


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
Webプッシュリマインダーの定期実行を本番環境で定期送信できるようにしました。
通知クリック時に、ジャーナル作成画面へ遷移する処理を追加しました。

## 変更内容
- Render Cron Jobによるリマインダー通知の定期実行設定
- Webプッシュ通知をクリックした際の画面遷移処理を追加

## 確認方法
  - 設定した時刻にWebプッシュ通知が届くこと
  - 通知をクリックするとジャーナル作成画面へ遷移すること
  - 通知設定を有効・無効に変更できること
  - 通知時刻を変更できること

## 関連Issue
closes #239 