### PR TITLE
style:フォントと月ナビゲーションの表示を調整

### DIFF
--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-4 pb-6 sm:pt-6 md:px-0">
 
-    <h1 class="font-semibold font-sans text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">
+    <h1 class="font-bold font-sans text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
     
@@ -35,7 +35,7 @@
                   </p>
                 </summary>
                 <div class="collapse-content text-sm">
-                  <p class="mb-1 mt-1">
+                  <p class="font-semibold mb-1 mt-1">
                   今回の添削
                   </p>
                   <p class="text-error mb-1">
@@ -45,7 +45,7 @@
                     <%= mistake.corrected_text %>
                   </p>
                   <hr class="border-primary mb-2 mt-2">
-                  <p class="mb-1">
+                  <p class="font-semibold mb-1">
                   似た表現・言い回し
                   </p>
                     <div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -57,11 +57,11 @@
           <% @journals.each do |journal| %>
             <%# 1件ずつ枠で囲む %>
              <%= link_to journal_path(journal) do %>
-            <div class="border border-base-300 bg-base-100 rounded-2xl p-4 mb-4">
+            <div class="group border border-base-300 bg-base-100 rounded-2xl p-4 mb-4 hover:bg-base-300">
             
             <p class="font-medium mb-2 items-center text-base-content/70 text-base sm:text-md flex gap-2">
               <%= journal.posted_date.strftime("%Y/%m/%d") %>
-              <span class="inline-flex items-center bg-secondary text-primary text-xs sm:text-sm rounded-full px-2 py-1">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
+              <span class="inline-flex items-center bg-secondary text-primary text-xs sm:text-sm rounded-full px-2 py-1 group-hover:bg-forest-500 group-hover:text-white">添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %></span>
             </p>
     
             <p class="text-base-content mb-3 line-clamp-2 text-sm sm:text-base">

--- a/app/views/journal_corrections/index.html.erb
+++ b/app/views/journal_corrections/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-4 pb-6 sm:pt-6 md:px-0">
-    <h1 class="font-semibold font-sans text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
+    <h1 class="font-bold font-sans text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
      <%= t('.title') %>
     </h1>
 

--- a/app/views/journal_corrections/show.html.erb
+++ b/app/views/journal_corrections/show.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
+    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
     

--- a/app/views/journals/calendar.html.erb
+++ b/app/views/journals/calendar.html.erb
@@ -1,19 +1,20 @@
 <% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
+
   <div class="max-w-5xl mx-auto w-full pt-2 pb-6 sm:pt-6 md:px-2">
-    <div class="w-full bg-base-100/80 p-4 sm:p-6 rounded-3xl">
-    
-    <div class="flex items-center justify-between flex-wrap">
-      <h1 class="text-lg sm:text-cl md:text-2xl font-semibold text-primary">
+      <div class="flex items-center justify-center flex-wrap">
+      <h1 class="font-sans text-lg text-center sm:text-2xl md:text-3xl font-bold mb-2">
         カレンダー
-        <span class="text-primary text-sm sm:text-base md:text-2xl">(<%= @year %>年 <%= @month %>月)</span>
+        <span class="text-lg sm:text-2xl md:text-3xl">(<%= @year %>年 <%= @month %>月)</span>
       </h1>
-      <div class="flex items-center gap-2 flex-wrap text-xs sm:text-sm">
+      <div class="flex w-full justify-end items-center gap-2 flex-wrap text-xs sm:text-sm">
         <%= link_to "前月", calendar_journals_path(year: @prev_year, month: @prev_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-secondary text-primary font-semibold hover:bg-forest-200" %>
         <%= link_to "今月", calendar_journals_path(year: @today.year, month: @today.month), class:"px-4 py-2 rounded-xl border border-primary bg-primary text-white font-semibold hover:bg-forest-600" %>
         <%= link_to "翌月", calendar_journals_path(year:@next_year, month:@next_month), class:"px-4 py-2 rounded-xl border border-forest-200 bg-secondary text-primary font-semibold hover:bg-forest-200" %>
       </div>
     </div>
+
+    <div class="w-full bg-base-100/80 p-4 sm:p-6 rounded-3xl mt-3">
 
     <!-- 曜日 -->
     <div class="mt-4 grid grid-cols-7 gap-2 text-center text-sm sm:text-md md:text-lg">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -16,13 +16,13 @@
       <% if@journals.any? %>
         <%# 日記一覧をループ %>
         <% @journals.each do |journal| %>
-          <div class="border border-base-300 bg-base-100 rounded-lg py-3 mb-3 px-4">
+          <div class="group border border-base-300 bg-base-100 rounded-lg py-3 mb-3 px-4 hover:bg-base-300">
 
             <div class="flex items-center gap-3">
               <span class="font-bold text-base-content/70">
                 <%= journal.posted_date.strftime("%Y/%m/%d") %>
               </span>
-              <span class="inline-flex items-center bg-secondary text-primary text-xs sm:text-sm rounded-full px-2 py-1">
+              <span class="inline-flex items-center bg-secondary text-primary text-xs sm:text-sm rounded-full px-2 py-1 group-hover:bg-forest-500 group-hover:text-white">
                 添削トーン：<%= t("enums.journal.tone.#{journal.tone}") %>
               </span>
               <span class="ml-auto">

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -2,7 +2,7 @@
 <div class="flex-grow px-4 sm:px-6 md:px-10"> 
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
   <!--<div class="max-w-3xl mx-auto md:px-0 pt-6 pb-12"> -->
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6"><%= t('.title') %></h1>
+    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6"><%= t('.title') %></h1>
       <%= render 'form', journal:@journal %>
   </div>
 </div>

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -2,11 +2,11 @@
 <div class="flex-grow px-4 sm:px-6 md:px-10">
    <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
     <%# ページタイトル %>
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
+    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 
-  <div class="flex justify-between">
+  <div class="flex justify-end gap-2">
   <% if @previous_journal.present? %>
     <%= link_to "前の日記", @previous_journal, class:"btn btn-sm border-primary text-primary hover:bg-primary hover:text-white" %>
   <% end %>

--- a/app/views/line_connections/show.html.erb
+++ b/app/views/line_connections/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-2xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">
+    <h1 class="font-sans font-bold text-lg sm:text-2xl md:text-3xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('.title', default: APP_NAME)) %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-3xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
+    <h1 class="font-sans font-bold text-lg md:text-3xl sm:text-2xl text-center mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
       <div class="card bg-base-100 shadow mb-4 p-3">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -2,7 +2,7 @@
 <% content_for :meta_description, "Capture Your Dayのプライバシーポリシーページです。" %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">
+    <h1 class="font-sans font-bold text-center text-lg md:text-3xl sm:text-2xl mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -2,7 +2,7 @@
 <% content_for :meta_description, "Capture Your Dayの利用規約ページです。" %>
 <div class="flex-grow px-4 sm:px-6 md:px-10">
   <div class="max-w-4xl mx-auto pt-2 pb-8 sm:pt-6 md:px-0">
-    <h1 class="font-sans font-semibold text-center text-lg sm:text-2xl md:text-3xl mb-4 sm:mb-6">
+    <h1 class="font-sans font-bold text-center text-lg sm:text-2xl md:text-3xl mb-4 sm:mb-6">
       <%= t('.title') %>
     </h1>
 

--- a/app/views/shared/_month_navigation.html.erb
+++ b/app/views/shared/_month_navigation.html.erb
@@ -2,13 +2,13 @@
 <div class="flex items-center justify-end gap-2 mb-4">
   <%= link_to "前月",
       path.call(year: prev_year, month: prev_month),
-      class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200 text-xs sm:text-sm" %>
+      class: "px-5 py-2 rounded-xl border border-forest-200 bg-secondary text-primary font-semibold hover:bg-forest-200 text-xs sm:text-sm" %>
   
   <div class="text-center">
     <% unless current_month == Date.current.beginning_of_month %>
       <%= link_to "今月",
           path.call(year: Date.current.year, month: Date.current.month),
-          class: "btn btn-sm border-primary bg-primary text-white hover:bg-forest-200 text-xs sm:text-sm" %>
+          class: "px-5 py-2 rounded-xl border border-primary bg-primary text-white font-semibold hover:bg-forest-200 text-xs sm:text-sm" %>
     <% end %>
   </div>
   
@@ -16,6 +16,6 @@
   <% if current_month < Date.current.beginning_of_month %>
     <%= link_to "翌月",
         path.call(year: next_year, month: next_month),
-        class: "btn btn-sm border-forest-200 bg-secondary text-primary hover:bg-forest-200 text-xs sm:text-sm" %>
+        class: "px-5 py-2 rounded-xl border border-forest-200 bg-secondary text-primary font-semibold hover:bg-forest-200 text-xs sm:text-sm" %>
   <% end %>
 </div>


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
各画面のタイトルのフォントや、月ナビゲーションのデザインを調整しました。

## 背景
なぜこの変更が必要だったか（Issueリンク）

## 変更内容
  ### 見出しの調整
  以下の画面で、見出しのフォントウェイトを`font-bold`に統一しました。
  - 保存した表現一覧
  - 表現一覧・詳細
  - 日記作成・詳細
  - LINE連携
  - マイページ
  - 利用規約
  - プライバシーポリシー
 
  ### カレンダー画面の調整
  - カレンダーの見出しを中央配置
  - 見出しの文字サイズと太さを調整
   - 月移動ボタンを押しやすい大きさに調整

## 関連Issue
closes #