### PR TITLE
fix: learning pointのプロンプト修正

### DIFF
--- a/app/services/journal_prompt_builder.rb
+++ b/app/services/journal_prompt_builder.rb
@@ -61,8 +61,8 @@ class JournalPromptBuilder
     ====================
     CORRECTION RULES
     ====================
-    - Return 3 to 5 notes for short input.
-    - Return 5 to 7 notes for longer input when there are enough useful learning points.
+    - Return 3 to 5 notes depending on how many genuinely useful corrections the input contains.
+    - Do not create extra notes merely to reach a target count.
 
     Do not only return the most serious mistakes.
     Include useful learning points from grammar, word choice, spelling, sentence structure, and natural expression.
@@ -79,9 +79,9 @@ class JournalPromptBuilder
     - learning_points:
       - label: short Japanese label for the learning point
       - pattern:#{' '}
-        reusable English grammar pattern or phrase pattern
-        Do not return overly broad patterns such as "in + noun", "with + noun", or "to + verb" unless that broad pattern is the main learning point.
-        The pattern should be specific enough to make a new sentence.
+        one complete, natural English expression copied exactly from corrected_text
+        Preserve what the learner personally wanted to say.
+        Never turn it into an abstract grammar template or replace words with placeholders.
       - review_tag: short lowercase English tag for review, such as preposition, tense, article, word_order, collocation, infinitive, gerund, expression, translation
 
     Grammar explanations should be practical:
@@ -98,14 +98,14 @@ class JournalPromptBuilder
     ====================
     QUALITY BAR FOR learning_points.pattern:
     Only choose expressions that are useful enough to review later.
-    Do not extract general grammar patterns that merely appear in the corrected sentence.
-    Prefer the largest structure needed to explain the correction.
+    Copy one complete, natural expression exactly as it appears in corrected_text.
+    Prefer a complete short sentence that preserves the learner's personal meaning.
     Always choose the learning point from the main corrected difference between original_text and corrected_text, not from
-    a grammar pattern that merely appears inside corrected_text.
+    a grammar structure that merely appears inside corrected_text.
 
     Do not invent grammar explanations.
     Before writing the explanation, identify the exact structure of the corrected phrase.
-    For comparison corrections, the learning point must explain the comparison structure, not a smaller phrase inside it.
+    For comparison corrections, explain the comparison structure in explanation, while pattern remains the complete corrected expression.
 
       Do NOT choose:
     - contractions: "I'm", "you're", "it's", "don't"
@@ -129,12 +129,10 @@ class JournalPromptBuilder
     - expressions that help the learner say feelings more naturally
 
     When creating the pattern:
-    - Preserve the actual main verb if it is useful or corrected.
-    - Preserve key prepositions and collocations.
-    - Replace only the variable part with a Japanese placeholder.
-    - Keep enough surrounding words so the learner can reuse the phrase naturally.
-      Use placeholders only for replaceable objects, people, places, times, nouns, or clauses.
-      Do not use placeholders for the main verb, auxiliary verb, or key preposition unless the learning point is specifically about grammar structure.
+    - Copy the words from corrected_text without replacing or generalizing any part.
+    - Include enough context to preserve the learner's intended meaning.
+    - Prefer a complete short sentence over a fragment.
+    - Put reusable grammar rules and generalized forms in explanation, not in pattern.
 
     Bad:
     - I'm + 動詞ing
@@ -151,21 +149,15 @@ class JournalPromptBuilder
     - more than + to + 動詞
 
     Good:
-    - My flight leaves at + 時刻
-    - arrive at + 場所 by + 時刻
-    - the bus that leaves at + 時刻
-    - be excited about + 名詞 / 動名詞
-    - I'm flying to + 場所
-    - I'm going to + 場所
-    - I'm heading to + 場所
-    - I'm taking + 交通手段
+    - My flight leaves at seven.
+    - I need to arrive at the airport by six.
+    - I'm excited about starting my new job.
     - It feels pretty early.
     - It feels a little awkward.
-    - I'm really looking forward to + 名詞 / 動名詞
-    - to + 動詞 more than to + 動詞, 動名詞 more than 動名詞,  名詞 more than 名詞
+    - I'm really looking forward to seeing her again.
 
     Good learning point:
-    pattern: to + 動詞 more than to + 動詞
+    pattern: I want to enjoy the process more than I want to reach the goal.
     meaning: 〜することより、〜すること
     explanation: more than で2つの行動を比べるときは、前後の文法の形をそろえると自然です。to + 動詞 と比べるなら、more than の後ろも to + 動詞 にします。動名詞と比べるなら、more than の後ろも動名詞にします。
 
@@ -173,24 +165,25 @@ class JournalPromptBuilder
     The corrected sentence may be natural and flexible, but the learning point must be a reusable natural English expression, not a description of how the sentence was translated.
 
     CRITICAL RULE:
-    If the learner cannot realistically create a full sentence using only the pattern, DO NOT select it.
-    Choose expressions that native speakers would naturally remember and reuse as one unit.
-    Use placeholders ONLY when native speakers naturally think of the expression as a reusable pattern.
+    If the selected expression is not complete and understandable by itself, DO NOT select it.
+    Choose expressions that learners can remember as one meaningful unit.
+    Never use placeholders in learning_points.pattern.
     If corrected_text contains a high-value idiomatic expression, choose it over a literal translation.
     #{' '}
     For learning_points.pattern:
     Learning point selection priority:
-    1. Choose the most useful reusable phrase, collocation, or grammar pattern from corrected_text.
+    1. Choose the most useful complete expression from corrected_text.
     2. Prefer expressions learners can reuse in daily journaling.
     3. Do not choose a basic grammar rule if corrected_text contains a more useful natural expression.
-    4. The pattern must be based on corrected_text, but do not make corrected_text unnatural just to match the pattern.
+    4. The pattern must be copied exactly from corrected_text, but do not make corrected_text unnatural just to provide a pattern.
     5. A pattern must teach a useful expression, not just an intensifier like "so", "very", "really", or "too".
 
     For learning_points.pattern:
-    - Do NOT copy the full corrected sentence as the pattern.
-    - The pattern must be a reusable phrase or structure, not a one-time translation.
-    - If the corrected_text is a full sentence, extract only the most reusable part.
-    - Use placeholders only when they make the expression naturally reusable.
+    - A learning point must be a complete short sentence or complete expression when it is natural, memorable, and useful for the learner's future journaling or conversation.
+    - Do not reduce a useful sentence to an abstract grammar frame.
+    - Preserve the learner's personal meaning whenever it makes the expression easier to remember and reuse.
+    - Copy it exactly from corrected_text.
+    - Never use placeholders such as "+ 名詞", "+ 動詞", "+ 形容詞", "+ 過去分詞", or "+ 文".
     - Reject patterns that are only a literal translation of the original Japanese.
     - Reject fragments that are unnatural when reused by themselves.
     - If there is no reusable learning point, do not create a note.
@@ -219,8 +212,7 @@ class JournalPromptBuilder
     - related_phrases must be semantic alternatives to learning_points.pattern, not examples of the same pattern.
     - phrase must be a reusable phrase pattern, not a full sentence.
     - example must be a complete sentence using that phrase.
-      Every learning_points.pattern and related_phrases.phrase must be grammatically complete enough for the learner
-      to reuse safely.
+      Every related_phrases.phrase must be grammatically complete enough for the learner to reuse safely.
       If the expression requires a fixed subject such as "I", include it.
       If the expression requires a following clause, write "+ 文(主語 + 動詞)".
       Do not omit required subjects.
@@ -232,22 +224,20 @@ class JournalPromptBuilder
     - what this feeling + 意味
     - wonder what it is about + 名詞
     - before + 動詞
+    - I hope to + 動詞
+    - I realized that + 文
+    - You know how + 文
+    - I haven't + 過去分詞
+    - want to + 動詞
 
     GOOD:
     - I don’t even know what this feeling is
     - I can’t quite put this feeling into words
     - I don’t know how to describe this feeling
     - It’s hard to put this feeling into words
-    - before + 動名詞
-
-      Do NOT use "+ 意味" as a placeholder.
-      Use only the approved placeholders:
-      + 名詞
-      + 動詞
-      + 動名詞
-      + 名詞 / 動名詞
-      + 人
-      + 文(主語 + 動詞)
+    - I realized I haven't been journaling lately.
+    - I haven't written in my diary for a while.
+    - I really want to keep it simple.
 
     Only create a note when it teaches a useful reusable point for the learner.
 
@@ -260,22 +250,13 @@ class JournalPromptBuilder
     1. Naturalness first: corrected_text must sound natural, emotionally authentic, and not overly formal.
     2. Prefer useful collocations and natural expressions over basic grammar frames.
     3. Choose patterns the learner can reuse for emotions, self-reflection, relationships, habits, worries, personal growth, and nuanced feelings.
-    4. The pattern should preferably be a reusable native-like phrase, collocation, or emotional expression.
+    4. The pattern should be a complete native-like phrase, short sentence, collocation, or emotional expression copied from corrected_text.
     5. Do not create a note for a change that is only a tiny style preference.
     6. Do not replace a natural casual expression with a more formal one unless the selected tone requires it.
-    7. learning_points.pattern must be based on a natural phrase in corrected_text.
+    7. learning_points.pattern must be copied exactly from a natural expression in corrected_text.
     8. The pattern should be large enough to preserve the natural emotional meaning and native usage. Do not reduce expressions into generic grammar skeletons.
-    9. Prefer patterns that capture the core meaning or emotional intent of the sentence, not just its structure. Grammar structures should only be selected when native speakers naturally think of them as reusable patterns.
-
-    Use only these Japanese placeholders in learning_points.pattern:
-    - + 名詞
-    - + 動詞
-    - + 動名詞
-    - + 名詞 / 動名詞
-    - + 人
-    - + 文(主語 + 動詞)#{' '}
-    - + 主語 + 動詞
-    - + 疑問文
+    9. Prefer expressions that capture the core meaning or emotional intent of the sentence, not just its structure.
+    10. Never use Japanese or English placeholders in learning_points.pattern.
 
     BAD:
     - be so + 形容詞
@@ -290,17 +271,16 @@ class JournalPromptBuilder
     - why can't they just + verb
 
     Good learning points:
-    - "insecurities about + 名詞"
-    - "share my feelings with + 人"
-    - "It often feels like + 主語 + 動詞"
-    - "have mixed feelings about + 名詞"
-    - "the way people think shapes + 名詞"
-    - "I think that's a good/the best way to + 動詞"
-    - "put what I want to say into English"
-    - "feel disconnected from + 人"
-    - "It makes me wonder if 文"
-    - "come from not having enough knowledge about + 名詞"
-    - "lack confidence in + 名詞"
+    - "I have a lot of insecurities about my English."
+    - "I want to share my feelings with my friends."
+    - "It often feels like I'm not making any progress."
+    - "The way people think shapes their behavior."
+    - "I think that's the best way to build confidence."
+    - "I struggle to put what I want to say into English."
+    - "I feel disconnected from the people around me."
+    - "It makes me wonder if I'm doing enough."
+    - "I think this fear comes from not knowing enough about it."
+    - "I lack confidence in my speaking skills."
 
     ====================
     INPUT
@@ -366,7 +346,7 @@ class JournalPromptBuilder
             "explanation": "text in Japanese (required)",
             "learning_points": {
               "label": "短い日本語ラベル。例: 前置詞 to の抜け 動詞の形 語彙選択など",
-              "pattern": "再利用できる英語の型。例: find it hard to + 動詞 + in that kind of environment / make progress with + 名詞 / 動名詞 という形",
+              "pattern": "corrected_textからそのまま抜き出した、プレースホルダーを含まない自然で完成した英語表現。例: I find it hard to focus in that kind of environment.",
               "meaning": "この表現の意味やニュアンス。例: 〜に対して感謝している",
               "review_tag": "復習用の短い英語タグ。例: preposition",
               "related_phrases": [

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -48,7 +48,7 @@
       </div>
     </div>
   
-        <h2 class="font-medium font-title text-lg sm:text-2xl md:text-3xl text-center font-cream-500 mb-3">
+        <h2 class="font-medium font-title text-xl sm:text-2xl md:text-3xl text-center font-cream-500 mb-3">
           Recent Journals
         </h2>
 

--- a/test/services/journal_prompt_builder_test.rb
+++ b/test/services/journal_prompt_builder_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class JournalPromptBuilderTest < ActiveSupport::TestCase
+  test "learning point requires a complete expression from corrected text" do
+    prompt = JournalPromptBuilder.new(
+      body: "最近、日記を書いていなかったことに気づいた。",
+      tone: "standard"
+    ).build
+
+    assert_includes prompt, "one complete, natural English expression copied exactly from corrected_text"
+    assert_includes prompt, "Never use Japanese or English placeholders in learning_points.pattern."
+    assert_includes prompt, "I realized I haven't been journaling lately."
+    assert_includes prompt, "Do not create extra notes merely to reach a target count."
+  end
+end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
AI添削時のleaning_pointに抽象的な文法パターンではなく、完成した英語表現が表示されるようにプロンプトを修正しました。

## 背景
これまでは、I hope to＋ 動詞 / I haven't 過去分詞 のような抽象化されたパターンが選ばれることがあり、あとから見直したときに再利用しづらい状態だったため。

## 変更内容
- `learning_points.pattern`には、`corrected_text`に含まれる自然な英語表現をそのまま使用するよう変更
- 完成した短文または表現を優先するよう変更
- `+ 動詞`、`+ 名詞`、`+ 文`などのプレースホルダーへの置き換えを禁止
- GOOD例をプレースホルダー形式から完成した英文へ変更

  ## 変更前
  - I hope to + 動詞
  - I realized that + 文
  - I really want to + 動詞

  ## 変更後
  - I hope to have my own pet.
  - I realized I haven't been journaling lately.
  - I really want to keep it simple.

## 関連Issue
closes #