### PR TITLE
fix:お気に入り登録を現在のユーザーに制限

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -23,8 +23,8 @@ class FavoritesController < ApplicationController
   end
 
   def create
-    # mistakes テーブル全体から、指定されたidのMistakeを1件探す
-    @mistake = Mistake.find(params[:mistake_id])
+    # 「ログイン中ユーザーが作成したmistakesの中から、指定されたidのMistakeを探す
+    @mistake = current_user.mistakes.find(params[:mistake_id])
     # ログイン中のユーザーが、そのmistakeをお気に入りする
     current_user.favorite(@mistake)
     # redirect_back fallback_location: mistakes_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,4 @@
 Rails.application.routes.draw do
-  get "favorites/create"
-  get "favorites/destroy"
   get "line_connections/show"
   get "mypages/show"
   get "home/index"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
お気に入り登録の対象を、ログイン中のユーザーのMistakeに制限しました。

## 変更内容
  - `Mistake.find` を `current_user.mistakes.find` に変更
  - ログイン中のユーザーが所有するMistakeだけをお気に入り登録できるように修正

## 関連Issue
closes #