### PR TITLE
fix:Mistakeにvalidationを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,4 +24,6 @@ class ApplicationController < ActionController::Base
   #   # アカウント更新（編集）時に :username カラムを許可する場合
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:username])
   # end
+
+  
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,4 @@ class ApplicationController < ActionController::Base
   #   # アカウント更新（編集）時に :username カラムを許可する場合
   #   devise_parameter_sanitizer.permit(:account_update, keys: [:username])
   # end
-
-  
 end

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -2,7 +2,6 @@ class Mistake < ApplicationRecord
   belongs_to :journal
   belongs_to :user
   belongs_to :journal_correction
-  validates :original_text, presence: true
   has_many :favorites, dependent: :destroy
 
   enum :mistake_type, { overall: 0, grammar: 1, spelling: 2, word_choice: 3, expression: 4, translation: 5 }

--- a/app/models/mistake.rb
+++ b/app/models/mistake.rb
@@ -6,5 +6,10 @@ class Mistake < ApplicationRecord
   has_many :favorites, dependent: :destroy
 
   enum :mistake_type, { overall: 0, grammar: 1, spelling: 2, word_choice: 3, expression: 4, translation: 5 }
+
+  validates :original_text, presence: true
+  validates :corrected_text, presence: true
+  validates :explanation, presence: true
+  validates :mistake_type, presence: true
 end
 # tense, present perfect, prepositions, gerunds, infinitives, or word order

--- a/spec/factories/mistakes.rb
+++ b/spec/factories/mistakes.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
 
     original_text { "I go to school yesterday." }
     corrected_text { "I went to school yesterday." }
+    explanation { "過去の出来事なので過去形を使います。" }
     mistake_type { "grammar" }
     learning_points { { pattern: "past tense" } }
   end

--- a/spec/models/mistake_spec.rb
+++ b/spec/models/mistake_spec.rb
@@ -13,6 +13,24 @@ RSpec.describe Mistake, type: :model do
       expect(mistake.errors[:original_text]).to include('を入力してください')
     end
 
+    it 'correcte_textが空白の場合は無効' do
+      mistake = build(:mistake, corrected_text: nil)
+      expect(mistake).to be_invalid
+      expect(mistake.errors[:corrected_text]).to include('を入力してください')
+    end
+
+    it 'explanationが空白の場合は無効' do
+      mistake = build(:mistake, explanation: nil)
+      expect(mistake).to be_invalid
+      expect(mistake.errors[:explanation]).to include('を入力してください')
+    end
+
+    it 'mistake_typeが空白の場合は無効' do
+      mistake = build(:mistake, mistake_type: nil)
+      expect(mistake).to be_invalid
+      expect(mistake.errors[:mistake_type]).to include('を入力してください')
+    end
+
     it 'mistake_typeに設定できること' do
         mistake = build(:mistake, mistake_type: 'grammar')
         expect(mistake.grammar?).to be true

--- a/test/controllers/journal_corrections_controller_test.rb
+++ b/test/controllers/journal_corrections_controller_test.rb
@@ -31,6 +31,7 @@ class JournalCorrectionsControllerTest < ActionDispatch::IntegrationTest
       user: @user,
       original_text: "I went school",
       corrected_text: "I went to school",
+      mistake_type: "grammar",
       explanation: "場所へ行く場合は go to + 場所を使います",
       learning_points: {
         "pattern" => "go to + 場所",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
AI添削した際に、空白のMistakeデータが保存されないようにバリデーションを追加しました。

## 変更内容
  - `corrected_text` を必須化
  - `explanation` を必須化
  - `mistake_type` を必須化

## 関連Issue
closes #