### PR TITLE
test:Web Pushのスペックを追加

### DIFF
--- a/spec/models/web_push_subscription_spec.rb
+++ b/spec/models/web_push_subscription_spec.rb
@@ -1,5 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe WebPushSubscription, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'endpointがない場合は無効' do
+    subscription = build(:web_push_subscription, endpoint: nil)
+
+    expect(subscription).not_to be_valid
+    expect(subscription.errors[:endpoint]).to be_present
+  end
+
+  it 'endpointが重複する場合は無効' do
+    existing_subscription = create(:web_push_subscription)
+    subscription = build(
+      :web_push_subscription,
+      endpoint: existing_subscription.endpoint
+    )
+
+    expect(subscription).not_to be_valid
+    expect(subscription.errors[:endpoint]).to be_present
+  end
+
+  it 'p256dhがない場合は無効' do
+    subscription = build(:web_push_subscription, p256dh: nil)
+
+    expect(subscription).not_to be_valid
+    expect(subscription.errors[:p256dh]).to be_present
+  end
+
+  it 'authがない場合は無効' do
+    subscription = build(:web_push_subscription, auth: nil)
+
+    expect(subscription).not_to be_valid
+    expect(subscription.errors[:auth]).to be_present
+  end
 end

--- a/spec/requests/web_push_subscriptions_spec.rb
+++ b/spec/requests/web_push_subscriptions_spec.rb
@@ -17,5 +17,47 @@ RSpec.describe "WebPushSubscriptions", type: :request do
 
       expect(response).to have_http_status(:success)
     end
+
+    it "ログインユーザーの購読情報を保存する" do
+      expect {
+        post "/web_push_subscriptions",
+            params: {
+              endpoint: "https://example.com/push",
+              p256dh: "dummy_p256dh",
+              auth: "dummy_auth"
+             }
+            }.to change(user.web_push_subscriptions, :count).by(1)
+
+      subscription = user.web_push_subscriptions.last
+
+      expect(subscription).to have_attributes(
+          endpoint: "https://example.com/push",
+          p256dh: "dummy_p256dh",
+          auth: "dummy_auth"
+      )
+    end
+
+    it "同じendpointの購買情報を重複登録せず更新する" do
+      subscription = create(
+        :web_push_subscription,
+        user: user,
+        endpoint: "https://example.com/push",
+        p256dh: "old_p256dh",
+        auth: "old_auth"
+      )
+
+    expect {
+      post "/web_push_subscriptions",
+           params: {
+           endpoint: subscription.endpoint,
+           p256dh: "new_p256dh",
+           auth: "new_auth"
+           }
+          }.not_to change(WebPushSubscription, :count)
+      expect(subscription.reload).to have_attributes(
+        p256dh: "new_p256dh",
+        auth: "new_auth"
+      )
+    end
   end
 end


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
Web Push通知のRSpecを追加しました。

## 変更内容
 - Web Push通知の送信条件に関するRSpecを追

## 関連Issue
closes #