### PR TITLE
Test / notification_settingsのRSpecを追加

### DIFF
--- a/spec/requests/notification_settings_spec.rb
+++ b/spec/requests/notification_settings_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "NotificationSettings", type: :request do
   let(:user) { create(:user) }
+
   before do
     sign_in user
   end
@@ -10,6 +11,53 @@ RSpec.describe "NotificationSettings", type: :request do
     it "returns http success" do
       get "/notification_setting"
       expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'PATCH/notification_setting' do
+
+    it '通知をOFFに更新できる' do
+      setting = create(
+        :notification_setting,
+        user: user,
+        reminder_enabled: true,
+        notification_time: "21:00"
+      )
+
+      expect {
+        patch "/notification_setting",
+             params: {
+               notification_setting: {
+                 reminder_enabled: "0",
+                 notification_time: "21:00"
+               }
+              }
+            }.to change {
+                setting.reload.reminder_enabled
+            }.from(true).to(false)
+
+        expect(response).to redirect_to(notification_setting_path)
+    end
+
+    it '通知ONで時刻が空の場合は更新できない' do
+      setting = create(
+        :notification_setting,
+        user: user,
+        reminder_enabled: false,
+        notification_time: nil
+      )
+
+      patch "/notification_setting",
+           params: {
+             notification_setting: {
+               reminder_enabled: "1",
+               notification_time: ""
+             }
+           }
+    
+    expect(response).to have_http_status(:unprocessable_entity)
+    expect(setting.reload.reminder_enabled).to be(false)
+    expect(setting.notification_time).to be_nil
     end
   end
 end

--- a/spec/requests/notification_settings_spec.rb
+++ b/spec/requests/notification_settings_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "NotificationSettings", type: :request do
   let(:user) { create(:user) }
@@ -14,8 +14,8 @@ RSpec.describe "NotificationSettings", type: :request do
     end
   end
 
-  describe 'PATCH/notification_setting' do
-    it '通知をOFFに更新できる' do
+  describe "PATCH / notification_setting" do
+    it "通知をOFFに更新できる" do
       setting = create(
         :notification_setting,
         user: user,
@@ -25,20 +25,20 @@ RSpec.describe "NotificationSettings", type: :request do
 
       expect {
         patch "/notification_setting",
-             params: {
-               notification_setting: {
-                 reminder_enabled: "0",
-                 notification_time: "21:00"
-               }
+              params: {
+                notification_setting: {
+                  reminder_enabled: "0",
+                  notification_time: "21:00"
+                }
               }
-            }.to change {
-                setting.reload.reminder_enabled
-            }.from(true).to(false)
+      }.to change {
+        setting.reload.reminder_enabled
+      }.from(true).to(false)
 
-        expect(response).to redirect_to(notification_setting_path)
+      expect(response).to redirect_to(notification_setting_path)
     end
 
-    it '通知ONで時刻が空の場合は更新できない' do
+    it "通知ONで時刻が空の場合は更新できない" do
       setting = create(
         :notification_setting,
         user: user,
@@ -47,16 +47,16 @@ RSpec.describe "NotificationSettings", type: :request do
       )
 
       patch "/notification_setting",
-           params: {
-             notification_setting: {
-               reminder_enabled: "1",
-               notification_time: ""
-             }
-           }
+            params: {
+              notification_setting: {
+                reminder_enabled: "1",
+                notification_time: ""
+              }
+            }
 
-    expect(response).to have_http_status(:unprocessable_entity)
-    expect(setting.reload.reminder_enabled).to be(false)
-    expect(setting.notification_time).to be_nil
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(setting.reload.reminder_enabled).to be(false)
+      expect(setting.notification_time).to be_nil
     end
   end
 end

--- a/spec/requests/notification_settings_spec.rb
+++ b/spec/requests/notification_settings_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "NotificationSettings", type: :request do
   end
 
   describe 'PATCH/notification_setting' do
-
     it '通知をOFFに更新できる' do
       setting = create(
         :notification_setting,
@@ -54,7 +53,7 @@ RSpec.describe "NotificationSettings", type: :request do
                notification_time: ""
              }
            }
-    
+
     expect(response).to have_http_status(:unprocessable_entity)
     expect(setting.reload.reminder_enabled).to be(false)
     expect(setting.notification_time).to be_nil


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->
## 概要
notification_settingsのRSpecを追加しました。

## 変更内容
  - リマインダー通知をOFFに更新できることを確認
  - 通知ONで通知時刻が未設定の場合、更新できないことを確認

## 関連Issue
closes #